### PR TITLE
Fix/91 cleanup permissions

### DIFF
--- a/.github/workflows/cleanup-branch.yaml
+++ b/.github/workflows/cleanup-branch.yaml
@@ -51,11 +51,11 @@ on:
       - '.github/workflows/**'
 
 # This is a test to see if the cleanup branch workflow works
-  push:
-    branches:
-      - 'fix/91-cleanup-permissions'
-    paths:
-      - '.github/workflows/cleanup-branch.yaml'
+  # push:
+  #   branches:
+  #     - 'fix/91-cleanup-permissions'
+  #   paths:
+  #     - '.github/workflows/cleanup-branch.yaml'
 
 
   workflow_dispatch:
@@ -77,7 +77,8 @@ jobs:
     timeout-minutes: 15
 
     # Only run if PR was merged, workflow_dispatch, or push (for testing)
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    # Add || github.event_name == 'push' for testing
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
 
     steps:
       # Step 1: Extract branch name


### PR DESCRIPTION
updates logic to get branch name in the same way that app.py does so that cleanup can be run manually even after the branch is merged

uses aws cli to delete the stack, cdk destroy runs all of app.py and would fail to get a branch stack on a PR. 