### PR TITLE
Feature/254 email only sign up

### DIFF
--- a/.github/workflows/infrastructure-deploy.yaml
+++ b/.github/workflows/infrastructure-deploy.yaml
@@ -247,6 +247,8 @@ jobs:
           BRANCH_STACK="${{ steps.get-stack-name.outputs.stack_name }}"
           if cdk deploy StrideSharedStack "$BRANCH_STACK" --require-approval never --outputs-file cdk-outputs.json; then
             echo "✅ Deployment successful!"
+            echo "Debug: cdk-outputs.json keys after deploy:"
+            jq -r 'keys[]' cdk-outputs.json || echo "Debug: could not read keys from cdk-outputs.json"
             echo "deployment_status=success" >> $GITHUB_OUTPUT
           else
             echo "❌ Deployment failed!"
@@ -267,6 +269,13 @@ jobs:
           SHARED_STACK_KEY="StrideSharedStack"
           BRANCH_STACK_KEY="${{ steps.get-stack-name.outputs.stack_name }}"
 
+          echo "Debug: expected branch stack key: $BRANCH_STACK_KEY"
+          echo "Debug: expected shared stack key: $SHARED_STACK_KEY"
+          echo "Debug: keys currently in cdk-outputs.json:"
+          jq -r 'keys[]' cdk-outputs.json
+          echo "Debug: full cdk-outputs.json contents:"
+          jq '.' cdk-outputs.json
+
           if ! jq -e ".\"$BRANCH_STACK_KEY\"" cdk-outputs.json >/dev/null 2>&1; then
             echo "Error: Branch stack outputs missing for key \"$BRANCH_STACK_KEY\""
             echo "Keys in cdk-outputs.json:"
@@ -276,7 +285,14 @@ jobs:
 
           if ! jq -e ".\"$SHARED_STACK_KEY\"" cdk-outputs.json >/dev/null 2>&1; then
             echo "Error: Shared stack outputs missing for key \"$SHARED_STACK_KEY\""
+            echo "Debug: cdk-outputs.json keys:"
             jq -r 'keys[]' cdk-outputs.json
+            echo "Debug: attempting CloudFormation lookup for shared stack outputs"
+            if aws cloudformation describe-stacks --stack-name "$SHARED_STACK_KEY" --query 'Stacks[0].Outputs' --output json; then
+              echo "Debug: CloudFormation lookup succeeded for $SHARED_STACK_KEY"
+            else
+              echo "Debug: CloudFormation lookup failed for $SHARED_STACK_KEY"
+            fi
             exit 1
           fi
 

--- a/.github/workflows/infrastructure-deploy.yaml
+++ b/.github/workflows/infrastructure-deploy.yaml
@@ -284,16 +284,10 @@ jobs:
           fi
 
           if ! jq -e ".\"$SHARED_STACK_KEY\"" cdk-outputs.json >/dev/null 2>&1; then
-            echo "Error: Shared stack outputs missing for key \"$SHARED_STACK_KEY\""
+            echo "Warning: Shared stack outputs missing for key \"$SHARED_STACK_KEY\" in cdk-outputs.json"
             echo "Debug: cdk-outputs.json keys:"
             jq -r 'keys[]' cdk-outputs.json
-            echo "Debug: attempting CloudFormation lookup for shared stack outputs"
-            if aws cloudformation describe-stacks --stack-name "$SHARED_STACK_KEY" --query 'Stacks[0].Outputs' --output json; then
-              echo "Debug: CloudFormation lookup succeeded for $SHARED_STACK_KEY"
-            else
-              echo "Debug: CloudFormation lookup failed for $SHARED_STACK_KEY"
-            fi
-            exit 1
+            echo "Debug: will fall back to CloudFormation for RdsSecretArn"
           fi
 
           # Branch stack: API, WebSocket, DynamoDB (per-environment)
@@ -321,7 +315,15 @@ jobs:
           # Shared RDS: single secret for schema + map seed (not emitted on branch stack)
           STRIDE_DB_ARN=$(jq -r ".\"$SHARED_STACK_KEY\".RdsSecretArn // empty" cdk-outputs.json 2>/dev/null || echo "")
           if [ -z "$STRIDE_DB_ARN" ] || [ "$STRIDE_DB_ARN" == "null" ]; then
-            echo "Error: Could not extract RdsSecretArn from $SHARED_STACK_KEY outputs"
+            echo "Warning: Could not extract RdsSecretArn from cdk-outputs.json for $SHARED_STACK_KEY"
+            echo "Debug: attempting CloudFormation lookup for shared RDS secret ARN"
+            STRIDE_DB_ARN=$(aws cloudformation describe-stacks \
+              --stack-name "$SHARED_STACK_KEY" \
+              --query "Stacks[0].Outputs[?OutputKey=='RdsSecretArn'].OutputValue | [0]" \
+              --output text 2>/dev/null || echo "")
+          fi
+          if [ -z "$STRIDE_DB_ARN" ] || [ "$STRIDE_DB_ARN" == "null" ] || [ "$STRIDE_DB_ARN" == "None" ]; then
+            echo "Error: Could not extract RdsSecretArn from cdk-outputs.json or CloudFormation"
             exit 1
           fi
 

--- a/aws_resources/backend/src/main/kotlin/com/handlers/AuthHandler.kt
+++ b/aws_resources/backend/src/main/kotlin/com/handlers/AuthHandler.kt
@@ -233,7 +233,7 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
             "UserNotFoundException" -> "User not found"
             "UserNotConfirmedException" -> "User account is not confirmed"
             "UsernameExistsException" -> "Username already exists"
-            "AliasExistsException" -> "An account with this email or phone number already exists"
+            "AliasExistsException" -> "An account with this email already exists"
             "InvalidPasswordException" -> "Password does not meet requirements"
             "InvalidParameterException" -> {
                 // Try to extract meaningful part from error message
@@ -367,12 +367,6 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
         return email?.trim()?.lowercase()?.takeIf { it.isNotBlank() }
     }
 
-    private fun normalizePhoneNumber(phone: String?): String? {
-        if (phone.isNullOrBlank()) return null
-        // Remove common formatting characters, let Cognito validate format
-        return phone.trim().replace(Regex("[\\s\\-\\(\\)\\.]"), "").takeIf { it.isNotBlank() }
-    }
-
     private fun normalizeUsername(username: String?): String? {
         return username?.trim()?.takeIf { it.isNotBlank() }
     }
@@ -410,39 +404,6 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
         }
     }
 
-    /**
-     * Checks if a phone number already exists in the Cognito user pool.
-     * Uses ListUsers API with phone_number filter to check for existing users.
-     * 
-     * @param userPoolId The Cognito user pool ID
-     * @param phoneNumber The phone number to check (should already be normalized/E.164 format)
-     * @param context Lambda context for logging
-     * @return true if phone number exists, false otherwise
-     */
-    private fun checkPhoneNumberExists(userPoolId: String, phoneNumber: String, context: Context): Boolean {
-        return try {
-            val listUsersRequest = ListUsersRequest.builder()
-                .userPoolId(userPoolId)
-                .filter("phone_number = \"${phoneNumber}\"")
-                .limit(1)
-                .build()
-            
-            val response = cognitoClient.listUsers(listUsersRequest)
-            val exists = response.users().isNotEmpty()
-            
-            if (exists) {
-                context.logger.log("Phone number already exists: $phoneNumber")
-            }
-            
-            exists
-        } catch (e: Exception) {
-            // Log error but don't fail registration - let Cognito handle it
-            // This prevents the check from blocking registration if there's an API issue
-            context.logger.log("WARNING: Failed to check phone number existence: ${e.message}")
-            false
-        }
-    }
-
     private fun handleRegister(
         input: APIGatewayProxyRequestEvent,
         context: Context
@@ -465,13 +426,12 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
                 mapper.readValue<RegisterRequest>(body)
             } catch (e: Exception) {
                 context.logger.log("ERROR: Failed to parse request body: ${e.message}")
-                return createErrorResponse(400, "Invalid request format. Expected JSON with username, password, passwordConfirm, firstName, lastName, and at least one of email or phoneNumber")
+                return createErrorResponse(400, "Invalid request format. Expected JSON with username, password, passwordConfirm, email, firstName, and lastName")
             }
 
             // Normalize inputs (trim whitespace, lowercase email)
             val normalizedUsername = normalizeUsername(registerRequest.username)
             val normalizedEmail = normalizeEmail(registerRequest.email)
-            val normalizedPhone = normalizePhoneNumber(registerRequest.phoneNumber)
             val normalizedPassword = registerRequest.password?.trim()
             val normalizedPasswordConfirm = registerRequest.passwordConfirm?.trim()
             val normalizedFirstName = registerRequest.firstName?.trim()?.takeIf { it.isNotBlank() }
@@ -483,8 +443,8 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
                 return createErrorResponse(400, "Username, password, passwordConfirm, firstName, and lastName are required")
             }
 
-            if (normalizedEmail == null && normalizedPhone == null) {
-                return createErrorResponse(400, "At least one of email or phoneNumber is required")
+            if (normalizedEmail == null) {
+                return createErrorResponse(400, "Email is required")
             }
             
             // Validate password confirmation
@@ -505,23 +465,12 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
                 return createErrorResponse(400, "Last name must be 64 characters or less")
             }
 
-            // Check for duplicate email (if provided)
-            if (normalizedEmail != null) {
-                val emailExists = checkEmailExists(userPoolId, normalizedEmail, context)
-                if (emailExists) {
-                    return createErrorResponse(409, "An account with this email already exists")
-                }
+            val emailExists = checkEmailExists(userPoolId, normalizedEmail, context)
+            if (emailExists) {
+                return createErrorResponse(409, "An account with this email already exists")
             }
 
-            // Check for duplicate phone number (if provided)
-            if (normalizedPhone != null) {
-                val phoneExists = checkPhoneNumberExists(userPoolId, normalizedPhone, context)
-                if (phoneExists) {
-                    return createErrorResponse(409, "An account with this phone number already exists")
-                }
-            }
-
-            // Build user attributes list and include only provided identifiers
+            // Build user attributes list and include the required email attribute.
             val userAttributes = mutableListOf(
                 software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType.builder()
                     .name("given_name")
@@ -530,24 +479,12 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
                 software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType.builder()
                     .name("family_name")
                     .value(normalizedLastName)  // Last name
+                    .build(),
+                AttributeType.builder()
+                    .name("email")
+                    .value(normalizedEmail)  // Already lowercase and validated
                     .build()
             )
-            if (normalizedEmail != null) {
-                userAttributes.add(
-                    AttributeType.builder()
-                        .name("email")
-                        .value(normalizedEmail)  // Already lowercase and validated
-                        .build()
-                )
-            }
-            if (normalizedPhone != null) {
-                userAttributes.add(
-                    AttributeType.builder()
-                        .name("phone_number")
-                        .value(normalizedPhone)  // Already normalized
-                        .build()
-                )
-            }
 
             // Create user in Cognito with normalized values
             val createUserRequest = AdminCreateUserRequest.builder()
@@ -640,7 +577,6 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
         val password: String?,
         val passwordConfirm: String?,
         val email: String?,
-        val phoneNumber: String?,
         val firstName: String?,
         val lastName: String?
     )

--- a/aws_resources/backend/src/main/kotlin/com/handlers/AuthHandler.kt
+++ b/aws_resources/backend/src/main/kotlin/com/handlers/AuthHandler.kt
@@ -465,7 +465,7 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
                 mapper.readValue<RegisterRequest>(body)
             } catch (e: Exception) {
                 context.logger.log("ERROR: Failed to parse request body: ${e.message}")
-                return createErrorResponse(400, "Invalid request format. Expected JSON with username, password, passwordConfirm, email, phoneNumber, firstName, and lastName")
+                return createErrorResponse(400, "Invalid request format. Expected JSON with username, password, passwordConfirm, firstName, lastName, and at least one of email or phoneNumber")
             }
 
             // Normalize inputs (trim whitespace, lowercase email)
@@ -478,9 +478,13 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
             val normalizedLastName = registerRequest.lastName?.trim()?.takeIf { it.isNotBlank() }
             
             // Validate required fields
-            if (normalizedUsername == null || normalizedPassword.isNullOrEmpty() || normalizedPasswordConfirm.isNullOrEmpty() || 
-                normalizedEmail == null || normalizedPhone == null || normalizedFirstName == null || normalizedLastName == null) {
-                return createErrorResponse(400, "Username, password, passwordConfirm, email, phoneNumber, firstName, and lastName are required")
+            if (normalizedUsername == null || normalizedPassword.isNullOrEmpty() || normalizedPasswordConfirm.isNullOrEmpty() ||
+                normalizedFirstName == null || normalizedLastName == null) {
+                return createErrorResponse(400, "Username, password, passwordConfirm, firstName, and lastName are required")
+            }
+
+            if (normalizedEmail == null && normalizedPhone == null) {
+                return createErrorResponse(400, "At least one of email or phoneNumber is required")
             }
             
             // Validate password confirmation
@@ -501,28 +505,24 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
                 return createErrorResponse(400, "Last name must be 64 characters or less")
             }
 
-            // Check for duplicate email
-            val emailExists = checkEmailExists(userPoolId, normalizedEmail, context)
-            if (emailExists) {
-                return createErrorResponse(409, "An account with this email already exists")
+            // Check for duplicate email (if provided)
+            if (normalizedEmail != null) {
+                val emailExists = checkEmailExists(userPoolId, normalizedEmail, context)
+                if (emailExists) {
+                    return createErrorResponse(409, "An account with this email already exists")
+                }
             }
 
-            // Check for duplicate phone number
-            val phoneExists = checkPhoneNumberExists(userPoolId, normalizedPhone, context)
-            if (phoneExists) {
-                return createErrorResponse(409, "An account with this phone number already exists")
+            // Check for duplicate phone number (if provided)
+            if (normalizedPhone != null) {
+                val phoneExists = checkPhoneNumberExists(userPoolId, normalizedPhone, context)
+                if (phoneExists) {
+                    return createErrorResponse(409, "An account with this phone number already exists")
+                }
             }
 
-            // Build user attributes list with all required fields
+            // Build user attributes list and include only provided identifiers
             val userAttributes = mutableListOf(
-                software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType.builder()
-                    .name("email")
-                    .value(normalizedEmail)  // Already lowercase and validated
-                    .build(),
-                software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType.builder()
-                    .name("phone_number")
-                    .value(normalizedPhone)  // Already in E.164 format
-                    .build(),
                 software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType.builder()
                     .name("given_name")
                     .value(normalizedFirstName)  // First name
@@ -532,6 +532,22 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
                     .value(normalizedLastName)  // Last name
                     .build()
             )
+            if (normalizedEmail != null) {
+                userAttributes.add(
+                    AttributeType.builder()
+                        .name("email")
+                        .value(normalizedEmail)  // Already lowercase and validated
+                        .build()
+                )
+            }
+            if (normalizedPhone != null) {
+                userAttributes.add(
+                    AttributeType.builder()
+                        .name("phone_number")
+                        .value(normalizedPhone)  // Already normalized
+                        .build()
+                )
+            }
 
             // Create user in Cognito with normalized values
             val createUserRequest = AdminCreateUserRequest.builder()

--- a/aws_resources/backend/src/test/kotlin/com/handlers/AuthHandlerTest.kt
+++ b/aws_resources/backend/src/test/kotlin/com/handlers/AuthHandlerTest.kt
@@ -341,6 +341,29 @@ class AuthHandlerTest {
     }
 
     @Test
+    @DisplayName("Register with both email and phone missing returns 400")
+    fun `register missing both identifiers returns 400`(envVars: EnvironmentVariables) {
+        // Given
+        envVars.set("USER_POOL_ID", "test-pool-id")
+
+        val event = APIGatewayProxyRequestEvent().apply {
+            httpMethod = "POST"
+            path = "/register"
+            body = """{"username":"testuser","password":"TestPass123!","passwordConfirm":"TestPass123!","firstName":"Test","lastName":"User","email":"","phoneNumber":""}"""
+        }
+
+        // When
+        val response = handler.handleRequest(event, mockContext)
+
+        // Then
+        assertEquals(400, response.statusCode)
+        val responseBody = response.body
+        assertNotNull(responseBody)
+        assertTrue(responseBody!!.contains("error"))
+        assertTrue(responseBody.contains("At least one of email or phoneNumber is required"))
+    }
+
+    @Test
     @DisplayName("Register with empty username returns 400")
     fun `register empty username returns 400`(envVars: EnvironmentVariables) {
         // Given
@@ -581,6 +604,25 @@ class AuthHandlerTest {
         // If not 400, that's fine - normalization passed
     }
 
+    @Test
+    @DisplayName("Register with only email does not fail identifier requirement")
+    fun `register with only email passes identifier validation`(envVars: EnvironmentVariables) {
+        // Given
+        envVars.set("USER_POOL_ID", "test-pool-id")
+
+        val event = createRegisterEvent("testuser", "TestPass123!", "TestPass123!", "test@example.com", "", "Test", "User")
+
+        // When
+        val response = handler.handleRequest(event, mockContext)
+
+        // Then - should not fail the at-least-one-identifier validation
+        val responseBody = response.body
+        if (response.statusCode == 400) {
+            assertNotNull(responseBody)
+            assertFalse(responseBody!!.contains("At least one of email or phoneNumber is required"))
+        }
+    }
+
     // Normalization tests (whitespace trimming)
 
     @Test
@@ -603,6 +645,25 @@ class AuthHandlerTest {
                 "Should not fail with phone/required field validation error")
         }
         // If not 400, that's fine - normalization passed
+    }
+
+    @Test
+    @DisplayName("Register with only phone does not fail identifier requirement")
+    fun `register with only phone passes identifier validation`(envVars: EnvironmentVariables) {
+        // Given
+        envVars.set("USER_POOL_ID", "test-pool-id")
+
+        val event = createRegisterEvent("testuser", "TestPass123!", "TestPass123!", "", "+1234567890", "Test", "User")
+
+        // When
+        val response = handler.handleRequest(event, mockContext)
+
+        // Then - should not fail the at-least-one-identifier validation
+        val responseBody = response.body
+        if (response.statusCode == 400) {
+            assertNotNull(responseBody)
+            assertFalse(responseBody!!.contains("At least one of email or phoneNumber is required"))
+        }
     }
 
     @Test

--- a/aws_resources/backend/src/test/kotlin/com/handlers/AuthHandlerTest.kt
+++ b/aws_resources/backend/src/test/kotlin/com/handlers/AuthHandlerTest.kt
@@ -364,6 +364,29 @@ class AuthHandlerTest {
     }
 
     @Test
+    @DisplayName("Register with email and phone fields omitted returns 400")
+    fun `register missing both identifiers when fields omitted returns 400`(envVars: EnvironmentVariables) {
+        // Given
+        envVars.set("USER_POOL_ID", "test-pool-id")
+
+        val event = APIGatewayProxyRequestEvent().apply {
+            httpMethod = "POST"
+            path = "/register"
+            body = """{"username":"testuser","password":"TestPass123!","passwordConfirm":"TestPass123!","firstName":"Test","lastName":"User"}"""
+        }
+
+        // When
+        val response = handler.handleRequest(event, mockContext)
+
+        // Then
+        assertEquals(400, response.statusCode)
+        val responseBody = response.body
+        assertNotNull(responseBody)
+        assertTrue(responseBody!!.contains("error"))
+        assertTrue(responseBody.contains("At least one of email or phoneNumber is required"))
+    }
+
+    @Test
     @DisplayName("Register with empty username returns 400")
     fun `register empty username returns 400`(envVars: EnvironmentVariables) {
         // Given

--- a/aws_resources/backend/src/test/kotlin/com/handlers/AuthHandlerTest.kt
+++ b/aws_resources/backend/src/test/kotlin/com/handlers/AuthHandlerTest.kt
@@ -241,14 +241,16 @@ class AuthHandlerTest {
         password: String,
         passwordConfirm: String,
         email: String,
-        phoneNumber: String,
+        _phoneNumber: String,
         firstName: String,
         lastName: String
     ): APIGatewayProxyRequestEvent {
+        // Kept for backwards-compatible test call sites while register is now email-only.
+        _phoneNumber.length
         return APIGatewayProxyRequestEvent().apply {
             httpMethod = "POST"
             path = "/register"
-            body = """{"username":"$username","password":"$password","passwordConfirm":"$passwordConfirm","email":"$email","phoneNumber":"$phoneNumber","firstName":"$firstName","lastName":"$lastName"}"""
+            body = """{"username":"$username","password":"$password","passwordConfirm":"$passwordConfirm","email":"$email","firstName":"$firstName","lastName":"$lastName"}"""
         }
     }
 
@@ -341,15 +343,15 @@ class AuthHandlerTest {
     }
 
     @Test
-    @DisplayName("Register with both email and phone missing returns 400")
-    fun `register missing both identifiers returns 400`(envVars: EnvironmentVariables) {
+    @DisplayName("Register with email missing returns 400")
+    fun `register missing email returns 400`(envVars: EnvironmentVariables) {
         // Given
         envVars.set("USER_POOL_ID", "test-pool-id")
 
         val event = APIGatewayProxyRequestEvent().apply {
             httpMethod = "POST"
             path = "/register"
-            body = """{"username":"testuser","password":"TestPass123!","passwordConfirm":"TestPass123!","firstName":"Test","lastName":"User","email":"","phoneNumber":""}"""
+            body = """{"username":"testuser","password":"TestPass123!","passwordConfirm":"TestPass123!","firstName":"Test","lastName":"User","email":""}"""
         }
 
         // When
@@ -360,12 +362,12 @@ class AuthHandlerTest {
         val responseBody = response.body
         assertNotNull(responseBody)
         assertTrue(responseBody!!.contains("error"))
-        assertTrue(responseBody.contains("At least one of email or phoneNumber is required"))
+        assertTrue(responseBody.contains("Email is required"))
     }
 
     @Test
-    @DisplayName("Register with email and phone fields omitted returns 400")
-    fun `register missing both identifiers when fields omitted returns 400`(envVars: EnvironmentVariables) {
+    @DisplayName("Register with email omitted returns 400")
+    fun `register missing email when field omitted returns 400`(envVars: EnvironmentVariables) {
         // Given
         envVars.set("USER_POOL_ID", "test-pool-id")
 
@@ -383,7 +385,7 @@ class AuthHandlerTest {
         val responseBody = response.body
         assertNotNull(responseBody)
         assertTrue(responseBody!!.contains("error"))
-        assertTrue(responseBody.contains("At least one of email or phoneNumber is required"))
+        assertTrue(responseBody.contains("Email is required"))
     }
 
     @Test
@@ -671,8 +673,8 @@ class AuthHandlerTest {
     }
 
     @Test
-    @DisplayName("Register with only phone does not fail identifier requirement")
-    fun `register with only phone passes identifier validation`(envVars: EnvironmentVariables) {
+    @DisplayName("Register with only phone fails because email is required")
+    fun `register with only phone fails email requirement`(envVars: EnvironmentVariables) {
         // Given
         envVars.set("USER_POOL_ID", "test-pool-id")
 
@@ -681,12 +683,11 @@ class AuthHandlerTest {
         // When
         val response = handler.handleRequest(event, mockContext)
 
-        // Then - should not fail the at-least-one-identifier validation
+        // Then
+        assertEquals(400, response.statusCode)
         val responseBody = response.body
-        if (response.statusCode == 400) {
-            assertNotNull(responseBody)
-            assertFalse(responseBody!!.contains("At least one of email or phoneNumber is required"))
-        }
+        assertNotNull(responseBody)
+        assertTrue(responseBody!!.contains("Email is required"))
     }
 
     @Test
@@ -799,7 +800,7 @@ class AuthHandlerTest {
         val event = APIGatewayProxyRequestEvent().apply {
             httpMethod = "POST"
             path = "/register"
-            body = """{"username":"testuser","password":"TestPass123!","email":"test@example.com","phoneNumber":"+1234567890","firstName":"Test","lastName":"User"}"""
+            body = """{"username":"testuser","password":"TestPass123!","email":"test@example.com","firstName":"Test","lastName":"User"}"""
         }
         
         // When

--- a/aws_resources/backend/tests/integration/test_login_api.py
+++ b/aws_resources/backend/tests/integration/test_login_api.py
@@ -31,7 +31,6 @@ def test_user_credentials():
         "password": "TestPass123!",
         "passwordConfirm": "TestPass123!",
         "email": f"test_{timestamp}_{random_suffix}@example.com",
-        "phoneNumber": f"+1555{timestamp % 10000000:07d}",  # Generate unique phone number
         "firstName": "Test",
         "lastName": "User"
     }
@@ -47,7 +46,6 @@ def test_login_success(api_base_url, test_user_credentials):
             "password": test_user_credentials["password"],
             "passwordConfirm": test_user_credentials["passwordConfirm"],
             "email": test_user_credentials["email"],
-            "phoneNumber": test_user_credentials["phoneNumber"],
             "firstName": test_user_credentials["firstName"],
             "lastName": test_user_credentials["lastName"]
         },
@@ -138,7 +136,6 @@ def test_login_whitespace_normalization(api_base_url, test_user_credentials):
             "password": test_user_credentials["password"],
             "passwordConfirm": test_user_credentials["passwordConfirm"],
             "email": test_user_credentials["email"],
-            "phoneNumber": test_user_credentials["phoneNumber"],
             "firstName": test_user_credentials["firstName"],
             "lastName": test_user_credentials["lastName"]
         },

--- a/aws_resources/backend/tests/integration/test_register_api.py
+++ b/aws_resources/backend/tests/integration/test_register_api.py
@@ -60,6 +60,50 @@ def test_register_success(api_base_url, test_user_credentials):
     assert "username" in data
 
 
+def test_register_email_only_success(api_base_url, test_user_credentials):
+    """Test successful user registration with email only."""
+    response = requests.post(
+        f"{api_base_url}/register",
+        json={
+            "username": f"{test_user_credentials['username']}_email_only",
+            "password": test_user_credentials["password"],
+            "passwordConfirm": test_user_credentials["passwordConfirm"],
+            "email": test_user_credentials["email"],
+            "firstName": test_user_credentials["firstName"],
+            "lastName": test_user_credentials["lastName"]
+        },
+        headers={"Content-Type": "application/json"},
+        timeout=10
+    )
+
+    assert response.status_code == 201, f"Expected 201, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert "message" in data
+    assert "username" in data
+
+
+def test_register_phone_only_success(api_base_url, test_user_credentials):
+    """Test successful user registration with phone only."""
+    response = requests.post(
+        f"{api_base_url}/register",
+        json={
+            "username": f"{test_user_credentials['username']}_phone_only",
+            "password": test_user_credentials["password"],
+            "passwordConfirm": test_user_credentials["passwordConfirm"],
+            "phoneNumber": test_user_credentials["phoneNumber"],
+            "firstName": test_user_credentials["firstName"],
+            "lastName": test_user_credentials["lastName"]
+        },
+        headers={"Content-Type": "application/json"},
+        timeout=10
+    )
+
+    assert response.status_code == 201, f"Expected 201, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert "message" in data
+    assert "username" in data
+
+
 def test_register_missing_fields(api_base_url):
     """Test registration with missing required fields."""
     # Missing email
@@ -77,6 +121,27 @@ def test_register_missing_fields(api_base_url):
     data = response.json()
     assert "error" in data
     assert "required" in data["error"].lower()
+
+
+def test_register_missing_email_and_phone(api_base_url):
+    """Test registration fails when both email and phoneNumber are absent."""
+    response = requests.post(
+        f"{api_base_url}/register",
+        json={
+            "username": "testuser_missing_identifiers",
+            "password": "TestPass123!",
+            "passwordConfirm": "TestPass123!",
+            "firstName": "Test",
+            "lastName": "User"
+        },
+        headers={"Content-Type": "application/json"},
+        timeout=10
+    )
+
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert "error" in data
+    assert data["error"] == "At least one of email or phoneNumber is required"
 
 
 def test_register_invalid_json(api_base_url):

--- a/aws_resources/backend/tests/integration/test_register_api.py
+++ b/aws_resources/backend/tests/integration/test_register_api.py
@@ -144,6 +144,29 @@ def test_register_missing_email_and_phone(api_base_url):
     assert data["error"] == "At least one of email or phoneNumber is required"
 
 
+def test_register_blank_email_and_phone(api_base_url):
+    """Test registration fails when email and phoneNumber are blank strings."""
+    response = requests.post(
+        f"{api_base_url}/register",
+        json={
+            "username": "testuser_blank_identifiers",
+            "password": "TestPass123!",
+            "passwordConfirm": "TestPass123!",
+            "email": "   ",
+            "phoneNumber": "  ",
+            "firstName": "Test",
+            "lastName": "User"
+        },
+        headers={"Content-Type": "application/json"},
+        timeout=10
+    )
+
+    assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert "error" in data
+    assert data["error"] == "At least one of email or phoneNumber is required"
+
+
 def test_register_invalid_json(api_base_url):
     """Test registration with invalid JSON."""
     response = requests.post(

--- a/aws_resources/backend/tests/integration/test_register_api.py
+++ b/aws_resources/backend/tests/integration/test_register_api.py
@@ -30,7 +30,6 @@ def test_user_credentials():
         "password": "TestPass123!",
         "passwordConfirm": "TestPass123!",
         "email": f"test_{timestamp}_{random_suffix}@example.com",
-        "phoneNumber": f"+1555{timestamp % 10000000:07d}",  # Generate unique phone number
         "firstName": "Test",
         "lastName": "User"
     }
@@ -45,7 +44,6 @@ def test_register_success(api_base_url, test_user_credentials):
             "password": test_user_credentials["password"],
             "passwordConfirm": test_user_credentials["passwordConfirm"],
             "email": test_user_credentials["email"],
-            "phoneNumber": test_user_credentials["phoneNumber"],
             "firstName": test_user_credentials["firstName"],
             "lastName": test_user_credentials["lastName"]
         },
@@ -60,53 +58,8 @@ def test_register_success(api_base_url, test_user_credentials):
     assert "username" in data
 
 
-def test_register_email_only_success(api_base_url, test_user_credentials):
-    """Test successful user registration with email only."""
-    response = requests.post(
-        f"{api_base_url}/register",
-        json={
-            "username": f"{test_user_credentials['username']}_email_only",
-            "password": test_user_credentials["password"],
-            "passwordConfirm": test_user_credentials["passwordConfirm"],
-            "email": test_user_credentials["email"],
-            "firstName": test_user_credentials["firstName"],
-            "lastName": test_user_credentials["lastName"]
-        },
-        headers={"Content-Type": "application/json"},
-        timeout=10
-    )
-
-    assert response.status_code == 201, f"Expected 201, got {response.status_code}: {response.text}"
-    data = response.json()
-    assert "message" in data
-    assert "username" in data
-
-
-def test_register_phone_only_success(api_base_url, test_user_credentials):
-    """Test successful user registration with phone only."""
-    response = requests.post(
-        f"{api_base_url}/register",
-        json={
-            "username": f"{test_user_credentials['username']}_phone_only",
-            "password": test_user_credentials["password"],
-            "passwordConfirm": test_user_credentials["passwordConfirm"],
-            "phoneNumber": test_user_credentials["phoneNumber"],
-            "firstName": test_user_credentials["firstName"],
-            "lastName": test_user_credentials["lastName"]
-        },
-        headers={"Content-Type": "application/json"},
-        timeout=10
-    )
-
-    assert response.status_code == 201, f"Expected 201, got {response.status_code}: {response.text}"
-    data = response.json()
-    assert "message" in data
-    assert "username" in data
-
-
 def test_register_missing_fields(api_base_url):
     """Test registration with missing required fields."""
-    # Missing email
     response = requests.post(
         f"{api_base_url}/register",
         json={
@@ -123,12 +76,12 @@ def test_register_missing_fields(api_base_url):
     assert "required" in data["error"].lower()
 
 
-def test_register_missing_email_and_phone(api_base_url):
-    """Test registration fails when both email and phoneNumber are absent."""
+def test_register_missing_email(api_base_url):
+    """Test registration fails when email is absent."""
     response = requests.post(
         f"{api_base_url}/register",
         json={
-            "username": "testuser_missing_identifiers",
+            "username": "testuser_missing_email",
             "password": "TestPass123!",
             "passwordConfirm": "TestPass123!",
             "firstName": "Test",
@@ -141,19 +94,18 @@ def test_register_missing_email_and_phone(api_base_url):
     assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
     data = response.json()
     assert "error" in data
-    assert data["error"] == "At least one of email or phoneNumber is required"
+    assert data["error"] == "Email is required"
 
 
-def test_register_blank_email_and_phone(api_base_url):
-    """Test registration fails when email and phoneNumber are blank strings."""
+def test_register_blank_email(api_base_url):
+    """Test registration fails when email is blank."""
     response = requests.post(
         f"{api_base_url}/register",
         json={
-            "username": "testuser_blank_identifiers",
+            "username": "testuser_blank_email",
             "password": "TestPass123!",
             "passwordConfirm": "TestPass123!",
             "email": "   ",
-            "phoneNumber": "  ",
             "firstName": "Test",
             "lastName": "User"
         },
@@ -164,7 +116,7 @@ def test_register_blank_email_and_phone(api_base_url):
     assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
     data = response.json()
     assert "error" in data
-    assert data["error"] == "At least one of email or phoneNumber is required"
+    assert data["error"] == "Email is required"
 
 
 def test_register_invalid_json(api_base_url):
@@ -191,7 +143,6 @@ def test_register_duplicate_username(api_base_url, test_user_credentials):
             "password": test_user_credentials["password"],
             "passwordConfirm": test_user_credentials["passwordConfirm"],
             "email": test_user_credentials["email"],
-            "phoneNumber": test_user_credentials["phoneNumber"],
             "firstName": test_user_credentials["firstName"],
             "lastName": test_user_credentials["lastName"]
         },
@@ -209,7 +160,6 @@ def test_register_duplicate_username(api_base_url, test_user_credentials):
             "password": "DifferentPass123!",
             "passwordConfirm": "DifferentPass123!",
             "email": f"different_{timestamp}@example.com",
-            "phoneNumber": f"+1555{timestamp % 10000000:07d}",
             "firstName": "Different",
             "lastName": "User"
         },
@@ -236,7 +186,6 @@ def test_register_email_lowercase_normalization(api_base_url, test_user_credenti
             "password": test_user_credentials["password"],
             "passwordConfirm": test_user_credentials["passwordConfirm"],
             "email": uppercase_email,
-            "phoneNumber": test_user_credentials["phoneNumber"],
             "firstName": test_user_credentials["firstName"],
             "lastName": test_user_credentials["lastName"]
         },
@@ -260,7 +209,6 @@ def test_register_whitespace_normalization(api_base_url, test_user_credentials):
             "password": f"  {test_user_credentials['password']}  ",
             "passwordConfirm": f"  {test_user_credentials['password']}  ",
             "email": f"  {test_user_credentials['email']}  ",
-            "phoneNumber": f"  {test_user_credentials['phoneNumber']}  ",
             "firstName": f"  {test_user_credentials['firstName']}  ",
             "lastName": f"  {test_user_credentials['lastName']}  "
         },
@@ -282,7 +230,6 @@ def test_register_duplicate_email(api_base_url, test_user_credentials):
             "password": test_user_credentials["password"],
             "passwordConfirm": test_user_credentials["passwordConfirm"],
             "email": test_user_credentials["email"],
-            "phoneNumber": test_user_credentials["phoneNumber"],
             "firstName": test_user_credentials["firstName"],
             "lastName": test_user_credentials["lastName"]
         },
@@ -301,7 +248,6 @@ def test_register_duplicate_email(api_base_url, test_user_credentials):
             "password": "DifferentPass123!",
             "passwordConfirm": "DifferentPass123!",
             "email": test_user_credentials["email"],  # Same email
-            "phoneNumber": f"+1555{timestamp % 10000000:07d}",  # Different phone
             "firstName": "Different",
             "lastName": "User"
         },
@@ -318,52 +264,6 @@ def test_register_duplicate_email(api_base_url, test_user_credentials):
     assert data["error"] == "An account with this email already exists"
 
 
-def test_register_duplicate_phone(api_base_url, test_user_credentials):
-    """Test registration with existing phone number."""
-    # Register first time
-    response1 = requests.post(
-        f"{api_base_url}/register",
-        json={
-            "username": test_user_credentials["username"],
-            "password": test_user_credentials["password"],
-            "passwordConfirm": test_user_credentials["passwordConfirm"],
-            "email": test_user_credentials["email"],
-            "phoneNumber": test_user_credentials["phoneNumber"],
-            "firstName": test_user_credentials["firstName"],
-            "lastName": test_user_credentials["lastName"]
-        },
-        headers={"Content-Type": "application/json"},
-        timeout=10
-    )
-    assert response1.status_code == 201, f"First registration failed: {response1.text}"
-
-    # Try to register again with same phone number but different username and email
-    timestamp = int(time.time())
-    random_suffix = ''.join(random.choices(string.ascii_lowercase, k=4))
-    response2 = requests.post(
-        f"{api_base_url}/register",
-        json={
-            "username": f"different_user_{timestamp}_{random_suffix}",
-            "password": "DifferentPass123!",
-            "passwordConfirm": "DifferentPass123!",
-            "email": f"different_{timestamp}_{random_suffix}@example.com",  # Different email
-            "phoneNumber": test_user_credentials["phoneNumber"],  # Same phone
-            "firstName": "Different",
-            "lastName": "User"
-        },
-        headers={"Content-Type": "application/json"},
-        timeout=10
-    )
-
-    assert response2.status_code == 409, f"Expected 409, got {response2.status_code}: {response2.text}"
-    data = response2.json()
-    assert "error" in data
-    assert "phone" in data["error"].lower()
-    assert "already exists" in data["error"].lower()
-    # Verify exact error message
-    assert data["error"] == "An account with this phone number already exists"
-
-
 def test_register_duplicate_email_case_insensitive(api_base_url, test_user_credentials):
     """Test that duplicate email check is case-insensitive (email is normalized to lowercase)."""
     # Register first time with lowercase email
@@ -374,7 +274,6 @@ def test_register_duplicate_email_case_insensitive(api_base_url, test_user_crede
             "password": test_user_credentials["password"],
             "passwordConfirm": test_user_credentials["passwordConfirm"],
             "email": test_user_credentials["email"],
-            "phoneNumber": test_user_credentials["phoneNumber"],
             "firstName": test_user_credentials["firstName"],
             "lastName": test_user_credentials["lastName"]
         },
@@ -394,7 +293,6 @@ def test_register_duplicate_email_case_insensitive(api_base_url, test_user_crede
             "password": "DifferentPass123!",
             "passwordConfirm": "DifferentPass123!",
             "email": uppercase_email,  # Same email, different case
-            "phoneNumber": f"+1555{timestamp % 10000000:07d}",  # Different phone
             "firstName": "Different",
             "lastName": "User"
         },
@@ -408,50 +306,6 @@ def test_register_duplicate_email_case_insensitive(api_base_url, test_user_crede
     assert "error" in data
     assert "email" in data["error"].lower()
     # Verify exact error message (case-insensitive check should work)
-    assert data["error"] == "An account with this email already exists"
-
-
-def test_register_duplicate_email_and_phone(api_base_url, test_user_credentials):
-    """Test that when both email and phone are duplicates, email check happens first."""
-    # Register first time
-    response1 = requests.post(
-        f"{api_base_url}/register",
-        json={
-            "username": test_user_credentials["username"],
-            "password": test_user_credentials["password"],
-            "passwordConfirm": test_user_credentials["passwordConfirm"],
-            "email": test_user_credentials["email"],
-            "phoneNumber": test_user_credentials["phoneNumber"],
-            "firstName": test_user_credentials["firstName"],
-            "lastName": test_user_credentials["lastName"]
-        },
-        headers={"Content-Type": "application/json"},
-        timeout=10
-    )
-    assert response1.status_code == 201, f"First registration failed: {response1.text}"
-
-    # Try to register again with both same email and phone number
-    timestamp = int(time.time())
-    random_suffix = ''.join(random.choices(string.ascii_lowercase, k=4))
-    response2 = requests.post(
-        f"{api_base_url}/register",
-        json={
-            "username": f"different_user_{timestamp}_{random_suffix}",
-            "password": "DifferentPass123!",
-            "passwordConfirm": "DifferentPass123!",
-            "email": test_user_credentials["email"],  # Same email
-            "phoneNumber": test_user_credentials["phoneNumber"],  # Same phone
-            "firstName": "Different",
-            "lastName": "User"
-        },
-        headers={"Content-Type": "application/json"},
-        timeout=10
-    )
-
-    # Should return 409 for email (email is checked first)
-    assert response2.status_code == 409, f"Expected 409, got {response2.status_code}: {response2.text}"
-    data = response2.json()
-    assert "error" in data
     assert data["error"] == "An account with this email already exists"
 
 
@@ -481,7 +335,6 @@ def test_register_invalid_email_format(api_base_url):
                 "password": "TestPass123!",
                 "passwordConfirm": "TestPass123!",
                 "email": invalid_email,
-                "phoneNumber": f"+1555{timestamp % 10000000:07d}",
                 "firstName": "Test",
                 "lastName": "User"
             },
@@ -492,46 +345,6 @@ def test_register_invalid_email_format(api_base_url):
         # Cognito should reject clearly invalid email formats
         # If it returns 201, that means Cognito accepted it (which is fine, we just verify it doesn't crash)
         assert response.status_code in [400, 201], f"Unexpected status {response.status_code} for email '{invalid_email}': {response.text}"
-        
-        if response.status_code == 400:
-            data = response.json()
-            assert "error" in data
-            # Error message should be user-friendly (sanitized by parseCognitoError)
-            assert len(data["error"]) > 0
-
-
-def test_register_invalid_phone_format(api_base_url):
-    """Test registration with invalid phone number format - Cognito will reject or accept based on its validation."""
-    # These are phone numbers that should be rejected by Cognito
-    # Note: Some formats might be normalized and accepted, so we test the ones that should definitely fail
-    invalid_phones = [
-        "123",  # Too short
-        "abc123",  # Contains letters (non-numeric)
-        "+0",  # Invalid country code (starts with 0)
-    ]
-    
-    for idx, invalid_phone in enumerate(invalid_phones):
-        timestamp = int(time.time())
-        random_suffix = ''.join(random.choices(string.ascii_lowercase, k=4))
-        
-        response = requests.post(
-            f"{api_base_url}/register",
-            json={
-                "username": f"testuser_{timestamp}_{random_suffix}_{idx}",
-                "password": "TestPass123!",
-                "passwordConfirm": "TestPass123!",
-                "email": f"test_{timestamp}_{random_suffix}_{idx}@example.com",
-                "phoneNumber": invalid_phone,
-                "firstName": "Test",
-                "lastName": "User"
-            },
-            headers={"Content-Type": "application/json"},
-            timeout=10
-        )
-        
-        # Cognito should reject clearly invalid phone formats
-        # If it returns 201, that means Cognito accepted it (which is fine, we just verify it doesn't crash)
-        assert response.status_code in [400, 201], f"Unexpected status {response.status_code} for phone '{invalid_phone}': {response.text}"
         
         if response.status_code == 400:
             data = response.json()
@@ -563,7 +376,6 @@ def test_register_weak_password_too_short(api_base_url):
                 "password": weak_password,
                 "passwordConfirm": weak_password,
                 "email": f"test_{timestamp}_{random_suffix}_{idx}@example.com",
-                "phoneNumber": f"+1555{timestamp % 10000000:07d}",
                 "firstName": "Test",
                 "lastName": "User"
             },
@@ -601,7 +413,6 @@ def test_register_weak_password_missing_requirements(api_base_url):
                 "password": weak_password,
                 "passwordConfirm": weak_password,
                 "email": f"test_{timestamp}_{random_suffix}_{idx}@example.com",
-                "phoneNumber": f"+1555{timestamp % 10000000:07d}",
                 "firstName": "Test",
                 "lastName": "User"
             },
@@ -678,7 +489,6 @@ def test_register_response_structure_success(api_base_url, test_user_credentials
             "password": test_user_credentials["password"],
             "passwordConfirm": test_user_credentials["passwordConfirm"],
             "email": test_user_credentials["email"],
-            "phoneNumber": test_user_credentials["phoneNumber"],
             "firstName": test_user_credentials["firstName"],
             "lastName": test_user_credentials["lastName"]
         },
@@ -760,7 +570,6 @@ def test_register_response_structure_duplicate(api_base_url, test_user_credentia
             "password": test_user_credentials["password"],
             "passwordConfirm": test_user_credentials["passwordConfirm"],
             "email": test_user_credentials["email"],
-            "phoneNumber": test_user_credentials["phoneNumber"],
             "firstName": test_user_credentials["firstName"],
             "lastName": test_user_credentials["lastName"]
         },
@@ -778,7 +587,6 @@ def test_register_response_structure_duplicate(api_base_url, test_user_credentia
             "password": "DifferentPass123!",
             "passwordConfirm": "DifferentPass123!",
             "email": f"different_{timestamp}@example.com",
-            "phoneNumber": f"+1555{timestamp % 10000000:07d}",
             "firstName": "Different",
             "lastName": "User"
         },

--- a/docs/Stride_API.postman_collection.json
+++ b/docs/Stride_API.postman_collection.json
@@ -142,12 +142,12 @@
 								"register"
 							]
 						},
-						"description": "Registers a new user in AWS Cognito with username, password, email, phone number, first name, and last name. All fields are required. The user is created with a permanent password and can immediately log in.\n\n**Input Normalization:**\n- Username is trimmed of leading/trailing whitespace\n- Email is trimmed and converted to lowercase\n- Phone number is trimmed and formatting characters are removed\n- First name and last name are trimmed\n- Password is trimmed\n- Cognito handles all format validation\n\n**Error Handling:**\n- Duplicate username or alias returns 409\n- Invalid password format returns 400\n- Missing required fields return 400\n- Server errors return 500"
+						"description": "Registers a new user in AWS Cognito with username, password, first name, last name, and at least one contact method (`email` or `phoneNumber`). Supplying both contact fields is also supported.\n\n**Input Normalization:**\n- Username is trimmed of leading/trailing whitespace\n- Email is trimmed and converted to lowercase\n- Phone number is trimmed and formatting characters are removed\n- First name and last name are trimmed\n- Password is trimmed\n- Cognito handles all format validation\n\n**Error Handling:**\n- Duplicate username or alias returns 409\n- Invalid password format returns 400\n- Missing required fields return 400\n- Server errors return 500"
 					},
 					"response": []
 				},
 				{
-					"name": "Register (Minimal)",
+					"name": "Register (Phone Only)",
 					"event": [
 						{
 							"listen": "test",
@@ -178,7 +178,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"username\": \"johndoe\",\n    \"password\": \"SecurePass123!\",\n    \"passwordConfirm\": \"SecurePass123!\",\n    \"email\": \"john.doe@example.com\",\n    \"phoneNumber\": \"+1234567890\",\n    \"firstName\": \"John\",\n    \"lastName\": \"Doe\"\n}",
+							"raw": "{\n    \"username\": \"johndoe\",\n    \"password\": \"SecurePass123!\",\n    \"passwordConfirm\": \"SecurePass123!\",\n    \"phoneNumber\": \"+1234567890\",\n    \"firstName\": \"John\",\n    \"lastName\": \"Doe\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -194,7 +194,59 @@
 								"register"
 							]
 						},
-						"description": "Registration with all required fields."
+						"description": "Registration example using only phoneNumber as the required contact field."
+					},
+					"response": []
+				},
+				{
+					"name": "Register (Email Only)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"if (pm.response.code === 201) {",
+									"    pm.test('Status code is 201', function () {",
+									"        pm.response.to.have.status(201);",
+									"    });",
+									"} else {",
+									"    pm.test('Error response has error field', function () {",
+									"        const jsonData = pm.response.json();",
+									"        pm.expect(jsonData).to.have.property('error');",
+									"    });",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"username\": \"alexdoe\",\n    \"password\": \"SecurePass123!\",\n    \"passwordConfirm\": \"SecurePass123!\",\n    \"email\": \"alex.doe@example.com\",\n    \"firstName\": \"Alex\",\n    \"lastName\": \"Doe\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/register",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"register"
+							]
+						},
+						"description": "Registration example using only email as the required contact field."
 					},
 					"response": []
 				}

--- a/docs/Stride_API.postman_collection.json
+++ b/docs/Stride_API.postman_collection.json
@@ -126,7 +126,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"username\": \"johndoe\",\n    \"password\": \"SecurePass123!\",\n    \"passwordConfirm\": \"SecurePass123!\",\n    \"email\": \"john.doe@example.com\",\n    \"phoneNumber\": \"+1234567890\",\n    \"firstName\": \"John\",\n    \"lastName\": \"Doe\"\n}",
+							"raw": "{\n    \"username\": \"johndoe\",\n    \"password\": \"SecurePass123!\",\n    \"passwordConfirm\": \"SecurePass123!\",\n    \"email\": \"john.doe@example.com\",\n    \"firstName\": \"John\",\n    \"lastName\": \"Doe\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -142,59 +142,7 @@
 								"register"
 							]
 						},
-						"description": "Registers a new user in AWS Cognito with username, password, first name, last name, and at least one contact method (`email` or `phoneNumber`). Supplying both contact fields is also supported.\n\n**Input Normalization:**\n- Username is trimmed of leading/trailing whitespace\n- Email is trimmed and converted to lowercase\n- Phone number is trimmed and formatting characters are removed\n- First name and last name are trimmed\n- Password is trimmed\n- Cognito handles all format validation\n\n**Error Handling:**\n- Duplicate username or alias returns 409\n- Invalid password format returns 400\n- Missing required fields return 400\n- Server errors return 500"
-					},
-					"response": []
-				},
-				{
-					"name": "Register (Phone Only)",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"if (pm.response.code === 201) {",
-									"    pm.test('Status code is 201', function () {",
-									"        pm.response.to.have.status(201);",
-									"    });",
-									"} else {",
-									"    pm.test('Error response has error field', function () {",
-									"        const jsonData = pm.response.json();",
-									"        pm.expect(jsonData).to.have.property('error');",
-									"    });",
-									"}"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"username\": \"johndoe\",\n    \"password\": \"SecurePass123!\",\n    \"passwordConfirm\": \"SecurePass123!\",\n    \"phoneNumber\": \"+1234567890\",\n    \"firstName\": \"John\",\n    \"lastName\": \"Doe\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseUrl}}/register",
-							"host": [
-								"{{baseUrl}}"
-							],
-							"path": [
-								"register"
-							]
-						},
-						"description": "Registration example using only phoneNumber as the required contact field."
+						"description": "Registers a new user in AWS Cognito with username, password, first name, last name, and email.\n\n**Input Normalization:**\n- Username is trimmed of leading/trailing whitespace\n- Email is trimmed and converted to lowercase\n- First name and last name are trimmed\n- Password is trimmed\n- Cognito handles all format validation\n\n**Error Handling:**\n- Duplicate username or alias returns 409\n- Invalid password format returns 400\n- Missing required fields return 400\n- Server errors return 500"
 					},
 					"response": []
 				},

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -154,14 +154,12 @@ paths:
       summary: User registration
       description: |
         Registers a new user in AWS Cognito with username, password, first name, last name,
-        and at least one contact method (`email` or `phoneNumber`). Supplying both contact
-        fields is also supported. The user is created with a permanent password and can
-        immediately log in.
+        and an email address. Registration is email-only.
+        The user is created with a permanent password and can immediately log in.
         
         **Input Normalization:**
         - Username is trimmed of leading/trailing whitespace
         - Email is trimmed and converted to lowercase
-        - Phone number is trimmed and formatting characters are removed
         - First name and last name are trimmed
         - Password is trimmed
         - Cognito handles all format validation
@@ -184,27 +182,8 @@ paths:
             schema:
               $ref: '#/components/schemas/RegisterRequest'
             examples:
-              validRegistrationWithBothContacts:
-                summary: Valid registration with both email and phone number
-                value:
-                  username: "johndoe"
-                  password: "SecurePass123!"
-                  passwordConfirm: "SecurePass123!"
-                  email: "john.doe@example.com"
-                  phoneNumber: "+1234567890"
-                  firstName: "John"
-                  lastName: "Doe"
-              validRegistrationPhoneOnly:
-                summary: Valid registration with phone only
-                value:
-                  username: "janedoe"
-                  password: "SecurePass123!"
-                  passwordConfirm: "SecurePass123!"
-                  phoneNumber: "+1234567890"
-                  firstName: "Jane"
-                  lastName: "Doe"
               validRegistrationEmailOnly:
-                summary: Valid registration with email only
+                summary: Valid registration (email required)
                 value:
                   username: "alexdoe"
                   password: "SecurePass123!"
@@ -234,11 +213,11 @@ paths:
                 missingFields:
                   summary: Missing required fields
                   value:
-                    error: "Username, password, passwordConfirm, firstName, and lastName are required, and at least one contact method (email or phoneNumber) must be provided"
+                    error: "Username, password, passwordConfirm, firstName, and lastName are required"
                 invalidFormat:
                   summary: Invalid JSON format
                   value:
-                    error: "Invalid request format. Expected JSON with username, password, passwordConfirm, firstName, lastName, and at least one of email or phoneNumber"
+                    error: "Invalid request format. Expected JSON with username, password, passwordConfirm, email, firstName, and lastName"
                 passwordMismatch:
                   summary: Passwords do not match
                   value:
@@ -267,9 +246,9 @@ paths:
                   value:
                     error: "Username already exists"
                 duplicateAlias:
-                  summary: Email or phone already exists
+                  summary: Email already exists
                   value:
-                    error: "An account with this email or phone number already exists"
+                    error: "An account with this email already exists"
         '429':
           description: Too many requests
           content:
@@ -356,65 +335,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /register/verify-phone:
-    post:
-      tags:
-        - Authentication
-      summary: Verify phone number
-      description: |
-        **⚠️ NOT IMPLEMENTED YET**
-        
-        Verifies a user's phone number using a verification code sent via SMS.
-        Uses Cognito's `VerifyUserAttribute` API.
-      operationId: verifyPhone
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - username
-                - code
-              properties:
-                username:
-                  type: string
-                  description: Username of the user to verify
-                  example: "johndoe"
-                code:
-                  type: string
-                  description: Verification code sent to the phone number
-                  example: "123456"
-      responses:
-        '200':
-          description: Phone number successfully verified
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    example: "Phone number verified successfully"
-        '400':
-          description: Bad request - invalid code or missing fields
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '404':
-          description: User not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
   /register/resend-code:
     post:
       tags:
@@ -423,7 +343,7 @@ paths:
       description: |
         **⚠️ NOT IMPLEMENTED YET**
         
-        Resends a verification code to the user's email or phone number.
+        Resends a verification code to the user's email.
         Uses Cognito's `ResendConfirmationCode` API.
       operationId: resendVerificationCode
       requestBody:
@@ -434,19 +354,11 @@ paths:
               type: object
               required:
                 - username
-                - type
               properties:
                 username:
                   type: string
                   description: Username of the user
                   example: "johndoe"
-                type:
-                  type: string
-                  description: Type of verification code to resend
-                  enum:
-                    - email
-                    - phone
-                  example: "email"
       responses:
         '200':
           description: Verification code resent successfully
@@ -459,7 +371,7 @@ paths:
                     type: string
                     example: "Verification code sent successfully"
         '400':
-          description: Bad request - invalid type or missing fields
+          description: Bad request - missing fields
           content:
             application/json:
               schema:
@@ -584,57 +496,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /register/check-phone:
-    get:
-      tags:
-        - Authentication
-      summary: Check phone number uniqueness
-      description: |
-        **⚠️ NOT IMPLEMENTED YET**
-        
-        Checks if a phone number is already registered.
-        Uses Cognito's `ListUsers` API with phone number filter to check for existing users.
-      operationId: checkPhoneUniqueness
-      parameters:
-        - name: phoneNumber
-          in: query
-          required: true
-          description: Phone number in E.164 format to check
-          schema:
-            type: string
-            pattern: '^\+?[1-9]\d{1,14}$'
-            example: "+1234567890"
-      responses:
-        '200':
-          description: Phone number uniqueness check result
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - available
-                properties:
-                  available:
-                    type: boolean
-                    description: Whether the phone number is available (not already registered)
-                    example: true
-                  phoneNumber:
-                    type: string
-                    description: The phone number that was checked
-                    example: "+1234567890"
-        '400':
-          description: Bad request - missing phoneNumber parameter or invalid format
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
   /refresh:
     post:
       tags:
@@ -703,7 +564,7 @@ paths:
         **⚠️ NOT IMPLEMENTED YET**
         
         Initiates a password reset flow by sending a verification code to the user's
-        registered email or phone number. Uses Cognito's `ForgotPassword` API.
+        registered email address. Uses Cognito's `ForgotPassword` API.
       operationId: forgotPassword
       requestBody:
         required: true
@@ -762,7 +623,7 @@ paths:
       description: |
         **⚠️ NOT IMPLEMENTED YET**
         
-        Resets the user's password using a verification code sent via email or SMS.
+        Resets the user's password using a verification code sent via email.
         Uses Cognito's `ConfirmForgotPassword` API.
       operationId: resetPassword
       requestBody:
@@ -1383,20 +1244,15 @@ components:
     RegisterRequest:
       type: object
       description: |
-        Registration payload. `username`, `password`, `passwordConfirm`, `firstName`, and
-        `lastName` are always required. At least one contact method (`email` or `phoneNumber`)
-        must be provided; both are allowed.
+        Registration payload. `username`, `password`, `passwordConfirm`, `email`,
+        `firstName`, and `lastName` are required.
       required:
         - username
         - password
         - passwordConfirm
+        - email
         - firstName
         - lastName
-      anyOf:
-        - required:
-            - email
-        - required:
-            - phoneNumber
       properties:
         username:
           type: string
@@ -1421,14 +1277,6 @@ components:
           description: User's email address (will be trimmed and lowercased)
           format: email
           example: "john.doe@example.com"
-        phoneNumber:
-          type: string
-          description: |
-            Phone number in E.164 format (e.g., +1234567890).
-            Formatting characters will be removed automatically.
-          example: "+1234567890"
-          pattern: '^\+?[1-9]\d{1,14}$'
-          minLength: 1
         firstName:
           type: string
           description: User's first name (will be trimmed)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -153,9 +153,10 @@ paths:
         - Authentication
       summary: User registration
       description: |
-        Registers a new user in AWS Cognito with username, password, email, phone number,
-        first name, and last name. All fields are required. The user is created with a permanent
-        password and can immediately log in.
+        Registers a new user in AWS Cognito with username, password, first name, last name,
+        and at least one contact method (`email` or `phoneNumber`). Supplying both contact
+        fields is also supported. The user is created with a permanent password and can
+        immediately log in.
         
         **Input Normalization:**
         - Username is trimmed of leading/trailing whitespace
@@ -183,8 +184,8 @@ paths:
             schema:
               $ref: '#/components/schemas/RegisterRequest'
             examples:
-              validRegistration:
-                summary: Valid registration with all required fields
+              validRegistrationWithBothContacts:
+                summary: Valid registration with both email and phone number
                 value:
                   username: "johndoe"
                   password: "SecurePass123!"
@@ -192,6 +193,24 @@ paths:
                   email: "john.doe@example.com"
                   phoneNumber: "+1234567890"
                   firstName: "John"
+                  lastName: "Doe"
+              validRegistrationPhoneOnly:
+                summary: Valid registration with phone only
+                value:
+                  username: "janedoe"
+                  password: "SecurePass123!"
+                  passwordConfirm: "SecurePass123!"
+                  phoneNumber: "+1234567890"
+                  firstName: "Jane"
+                  lastName: "Doe"
+              validRegistrationEmailOnly:
+                summary: Valid registration with email only
+                value:
+                  username: "alexdoe"
+                  password: "SecurePass123!"
+                  passwordConfirm: "SecurePass123!"
+                  email: "alex.doe@example.com"
+                  firstName: "Alex"
                   lastName: "Doe"
       responses:
         '201':
@@ -215,11 +234,11 @@ paths:
                 missingFields:
                   summary: Missing required fields
                   value:
-                    error: "Username, password, passwordConfirm, email, phoneNumber, firstName, and lastName are required"
+                    error: "Username, password, passwordConfirm, firstName, and lastName are required, and at least one contact method (email or phoneNumber) must be provided"
                 invalidFormat:
                   summary: Invalid JSON format
                   value:
-                    error: "Invalid request format. Expected JSON with username, password, passwordConfirm, email, phoneNumber, firstName, and lastName"
+                    error: "Invalid request format. Expected JSON with username, password, passwordConfirm, firstName, lastName, and at least one of email or phoneNumber"
                 passwordMismatch:
                   summary: Passwords do not match
                   value:
@@ -1363,14 +1382,21 @@ components:
 
     RegisterRequest:
       type: object
+      description: |
+        Registration payload. `username`, `password`, `passwordConfirm`, `firstName`, and
+        `lastName` are always required. At least one contact method (`email` or `phoneNumber`)
+        must be provided; both are allowed.
       required:
         - username
         - password
         - passwordConfirm
-        - email
-        - phoneNumber
         - firstName
         - lastName
+      anyOf:
+        - required:
+            - email
+        - required:
+            - phoneNumber
       properties:
         username:
           type: string

--- a/frontend/__tests__/register-contact.test.tsx
+++ b/frontend/__tests__/register-contact.test.tsx
@@ -119,9 +119,9 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       expect(screen.getByText(/Create your.*Stride.*account/)).toBeTruthy();
     });
 
-    it("renders the 'Step 3 of 3: Email & Contact' label", () => {
+    it("renders the 'Step 3 of 3: Contact' label", () => {
       render(<RegisterContact />);
-      expect(screen.getByText("Step 3 of 3: Email & Contact")).toBeTruthy();
+      expect(screen.getByText("Step 3 of 3: Contact")).toBeTruthy();
     });
 
     it("does not render the email text field by default", () => {

--- a/frontend/__tests__/register-contact.test.tsx
+++ b/frontend/__tests__/register-contact.test.tsx
@@ -124,14 +124,19 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       expect(screen.getByText("Step 3 of 3: Email & Contact")).toBeTruthy();
     });
 
-    it("renders the email text field", () => {
+    it("does not render the email text field by default", () => {
       render(<RegisterContact />);
-      expect(screen.getByPlaceholderText("Email")).toBeTruthy();
+      expect(screen.queryByPlaceholderText("Email")).toBeNull();
     });
 
     it("renders the phone number text field", () => {
       render(<RegisterContact />);
       expect(screen.getByPlaceholderText("Phone Number")).toBeTruthy();
+    });
+
+    it("defaults to phone mode with email toggle text", () => {
+      render(<RegisterContact />);
+      expect(screen.getByText("Use email instead")).toBeTruthy();
     });
 
     it("renders the 'Create Account' button", () => {
@@ -145,11 +150,43 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
     });
   });
 
+  describe("Contact mode toggle", () => {
+    it("toggles from phone mode to email mode", () => {
+      render(<RegisterContact />);
+
+      fireEvent.press(screen.getByText("Use email instead"));
+      expect(screen.getByText("Use phone instead")).toBeTruthy();
+      expect(screen.getByPlaceholderText("Email")).toBeTruthy();
+      expect(screen.queryByPlaceholderText("Phone Number")).toBeNull();
+    });
+  });
+
   // --- Email validation ---
 
   describe("Email validation", () => {
-    it("shows 'Email is required' error when creating account with empty email", async () => {
+    it("does not require email in default phone mode", async () => {
       render(<RegisterContact />);
+
+      const phoneInput = screen.getByPlaceholderText("Phone Number");
+      fireEvent.changeText(phoneInput, "8122949840");
+      const createAccountButton = screen.getByText("Create Account");
+      await act(async () => {
+        fireEvent.press(createAccountButton);
+        await waitFor(() => {
+          expect(mockApiRegister).toHaveBeenCalled();
+        });
+      });
+
+      expect(mockApiRegister).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          email: expect.any(String),
+        })
+      );
+    });
+
+    it("shows 'Email is required' in email mode when creating account with empty email", async () => {
+      render(<RegisterContact />);
+      fireEvent.press(screen.getByText("Use email instead"));
 
       const createAccountButton = screen.getByText("Create Account");
       fireEvent.press(createAccountButton);
@@ -157,18 +194,16 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       await waitFor(() => {
         expect(screen.getByText("Email is required")).toBeTruthy();
       });
-
       expect(mockApiRegister).not.toHaveBeenCalled();
     });
 
-    it("shows 'Please enter a valid email address' error for invalid email", async () => {
+    it("shows 'Please enter a valid email address' error for invalid email in email mode", async () => {
       render(<RegisterContact />);
+      fireEvent.press(screen.getByText("Use email instead"));
 
       const emailInput = screen.getByPlaceholderText("Email");
       fireEvent.changeText(emailInput, "invalid-email");
-
-      const createAccountButton = screen.getByText("Create Account");
-      fireEvent.press(createAccountButton);
+      fireEvent.press(screen.getByText("Create Account"));
 
       await waitFor(() => {
         expect(screen.getByText("Please enter a valid email address")).toBeTruthy();
@@ -179,12 +214,10 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
 
     it("accepts valid email addresses", async () => {
       render(<RegisterContact />);
+      fireEvent.press(screen.getByText("Use email instead"));
 
       const emailInput = screen.getByPlaceholderText("Email");
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-
       fireEvent.changeText(emailInput, "test@example.com");
-      fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
       await act(async () => {
@@ -203,12 +236,10 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
 
     it("trims whitespace from email before validation", async () => {
       render(<RegisterContact />);
+      fireEvent.press(screen.getByText("Use email instead"));
 
       const emailInput = screen.getByPlaceholderText("Email");
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-
       fireEvent.changeText(emailInput, "  test@example.com  ");
-      fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
       await act(async () => {
@@ -232,9 +263,6 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
     it("shows 'Phone number is required' error when creating account with empty phone", async () => {
       render(<RegisterContact />);
 
-      const emailInput = screen.getByPlaceholderText("Email");
-      fireEvent.changeText(emailInput, "test@example.com");
-
       const createAccountButton = screen.getByText("Create Account");
       fireEvent.press(createAccountButton);
 
@@ -247,11 +275,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
 
     it("shows 'Please enter a valid phone number' error for invalid phone", async () => {
       render(<RegisterContact />);
-
-      const emailInput = screen.getByPlaceholderText("Email");
       const phoneInput = screen.getByPlaceholderText("Phone Number");
-
-      fireEvent.changeText(emailInput, "test@example.com");
       fireEvent.changeText(phoneInput, "123");
 
       const createAccountButton = screen.getByText("Create Account");
@@ -262,6 +286,27 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       });
 
       expect(mockApiRegister).not.toHaveBeenCalled();
+    });
+
+    it("does not require phone in email mode", async () => {
+      render(<RegisterContact />);
+
+      fireEvent.press(screen.getByText("Use email instead"));
+      fireEvent.changeText(screen.getByPlaceholderText("Email"), "test@example.com");
+
+      const createAccountButton = screen.getByText("Create Account");
+      await act(async () => {
+        fireEvent.press(createAccountButton);
+        await waitFor(() => {
+          expect(mockApiRegister).toHaveBeenCalled();
+        });
+      });
+
+      expect(mockApiRegister).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          phoneNumber: expect.any(String),
+        })
+      );
     });
 
     it("formats phone number as user types", () => {
@@ -276,11 +321,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
 
     it("accepts valid phone numbers", async () => {
       render(<RegisterContact />);
-
-      const emailInput = screen.getByPlaceholderText("Email");
       const phoneInput = screen.getByPlaceholderText("Phone Number");
-
-      fireEvent.changeText(emailInput, "test@example.com");
       fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
@@ -303,13 +344,9 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
   // --- API integration ---
 
   describe("API integration", () => {
-    it("calls register() API with all form data when form is valid", async () => {
+    it("calls register() API with phone-only data in default mode", async () => {
       render(<RegisterContact />);
-
-      const emailInput = screen.getByPlaceholderText("Email");
       const phoneInput = screen.getByPlaceholderText("Phone Number");
-
-      fireEvent.changeText(emailInput, "test@example.com");
       fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
@@ -324,7 +361,6 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
         username: "testuser",
         password: "ValidPass123!",
         passwordConfirm: "ValidPass123!",
-        email: "test@example.com",
         phoneNumber: "+18122949840",
         firstName: "John",
         lastName: "Doe",
@@ -333,11 +369,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
 
     it("calls login() API after successful registration", async () => {
       render(<RegisterContact />);
-
-      const emailInput = screen.getByPlaceholderText("Email");
       const phoneInput = screen.getByPlaceholderText("Phone Number");
-
-      fireEvent.changeText(emailInput, "test@example.com");
       fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
@@ -359,11 +391,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
 
     it("calls authLogin() with tokens after successful login", async () => {
       render(<RegisterContact />);
-
-      const emailInput = screen.getByPlaceholderText("Email");
       const phoneInput = screen.getByPlaceholderText("Phone Number");
-
-      fireEvent.changeText(emailInput, "test@example.com");
       fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
@@ -383,11 +411,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
 
     it("navigates to /home after successful registration and login", async () => {
       render(<RegisterContact />);
-
-      const emailInput = screen.getByPlaceholderText("Email");
       const phoneInput = screen.getByPlaceholderText("Phone Number");
-
-      fireEvent.changeText(emailInput, "test@example.com");
       fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
@@ -410,11 +434,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockApiRegister.mockReturnValueOnce(registerPromise);
 
       const { UNSAFE_root } = render(<RegisterContact />);
-
-      const emailInput = screen.getByPlaceholderText("Email");
       const phoneInput = screen.getByPlaceholderText("Phone Number");
-
-      fireEvent.changeText(emailInput, "test@example.com");
       fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
@@ -444,11 +464,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockApiRegister.mockRejectedValueOnce(error);
 
       render(<RegisterContact />);
-
-      const emailInput = screen.getByPlaceholderText("Email");
       const phoneInput = screen.getByPlaceholderText("Phone Number");
-
-      fireEvent.changeText(emailInput, "test@example.com");
       fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
@@ -467,11 +483,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockApiRegister.mockRejectedValueOnce(error);
 
       render(<RegisterContact />);
-
-      const emailInput = screen.getByPlaceholderText("Email");
       const phoneInput = screen.getByPlaceholderText("Phone Number");
-
-      fireEvent.changeText(emailInput, "test@example.com");
       fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
@@ -512,12 +524,9 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockApiRegister.mockRejectedValueOnce(error);
 
       render(<RegisterContact />);
-
+      fireEvent.press(screen.getByText("Use email instead"));
       const emailInput = screen.getByPlaceholderText("Email");
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-
       fireEvent.changeText(emailInput, "test@example.com");
-      fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
       await act(async () => {
@@ -536,11 +545,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockApiRegister.mockRejectedValueOnce(error);
 
       render(<RegisterContact />);
-
-      const emailInput = screen.getByPlaceholderText("Email");
       const phoneInput = screen.getByPlaceholderText("Phone Number");
-
-      fireEvent.changeText(emailInput, "test@example.com");
       fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
@@ -558,11 +563,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockApiRegister.mockRejectedValueOnce(error);
 
       render(<RegisterContact />);
-
-      const emailInput = screen.getByPlaceholderText("Email");
       const phoneInput = screen.getByPlaceholderText("Phone Number");
-
-      fireEvent.changeText(emailInput, "test@example.com");
       fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
@@ -602,11 +603,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockApiLogin.mockRejectedValueOnce(loginError);
 
       render(<RegisterContact />);
-
-      const emailInput = screen.getByPlaceholderText("Email");
       const phoneInput = screen.getByPlaceholderText("Phone Number");
-
-      fireEvent.changeText(emailInput, "test@example.com");
       fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");
@@ -648,11 +645,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockParams = {};
 
       render(<RegisterContact />);
-
-      const emailInput = screen.getByPlaceholderText("Email");
       const phoneInput = screen.getByPlaceholderText("Phone Number");
-
-      fireEvent.changeText(emailInput, "test@example.com");
       fireEvent.changeText(phoneInput, "8122949840");
 
       const createAccountButton = screen.getByText("Create Account");

--- a/frontend/__tests__/register-contact.test.tsx
+++ b/frontend/__tests__/register-contact.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Integration tests for registration screen Step 3 (app/(auth)/register-contact.tsx)
  * 
- * Tests the final step of registration including email/phone validation,
+ * Tests the final step of registration including email validation,
  * API integration (register + auto-login), error handling, and navigation.
  */
 
@@ -50,41 +50,6 @@ jest.mock("../contexts/AuthContext", () => ({
   }),
 }));
 
-// Mock libphonenumber-js
-jest.mock("libphonenumber-js", () => ({
-  parsePhoneNumber: jest.fn((phone, country) => {
-    // Simple mock - return valid phone number for 10-digit US numbers
-    const digits = phone.replace(/\D/g, "");
-    if (digits.length === 10) {
-      return {
-        isValid: () => true,
-        number: `+1${digits}`,
-      };
-    }
-    if (digits.length === 11 && digits.startsWith("1")) {
-      return {
-        isValid: () => true,
-        number: `+${digits}`,
-      };
-    }
-    return {
-      isValid: () => false,
-      number: null,
-    };
-  }),
-  AsYouType: jest.fn().mockImplementation((country) => {
-    return {
-      input: (digits: string) => {
-        // Simple formatting: (XXX) XXX-XXXX for 10 digits
-        const cleaned = digits.replace(/\D/g, "");
-        if (cleaned.length <= 3) return cleaned;
-        if (cleaned.length <= 6) return `(${cleaned.slice(0, 3)}) ${cleaned.slice(3)}`;
-        return `(${cleaned.slice(0, 3)}) ${cleaned.slice(3, 6)}-${cleaned.slice(6, 10)}`;
-      },
-    };
-  }),
-}));
-
 // Mock Alert.alert
 const alertSpy = jest.spyOn(Alert, "alert");
 
@@ -119,24 +84,14 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       expect(screen.getByText(/Create your.*Stride.*account/)).toBeTruthy();
     });
 
-    it("renders the 'Step 3 of 3: Contact' label", () => {
+    it("renders the 'Step 3 of 3: Email' label", () => {
       render(<RegisterContact />);
-      expect(screen.getByText("Step 3 of 3: Contact")).toBeTruthy();
+      expect(screen.getByText("Step 3 of 3: Email")).toBeTruthy();
     });
 
-    it("does not render the email text field by default", () => {
+    it("renders the email text field", () => {
       render(<RegisterContact />);
-      expect(screen.queryByPlaceholderText("Email")).toBeNull();
-    });
-
-    it("renders the phone number text field", () => {
-      render(<RegisterContact />);
-      expect(screen.getByPlaceholderText("Phone Number")).toBeTruthy();
-    });
-
-    it("defaults to phone mode with email toggle text", () => {
-      render(<RegisterContact />);
-      expect(screen.getByText("Use email instead")).toBeTruthy();
+      expect(screen.getByPlaceholderText("Email")).toBeTruthy();
     });
 
     it("renders the 'Create Account' button", () => {
@@ -150,43 +105,11 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
     });
   });
 
-  describe("Contact mode toggle", () => {
-    it("toggles from phone mode to email mode", () => {
-      render(<RegisterContact />);
-
-      fireEvent.press(screen.getByText("Use email instead"));
-      expect(screen.getByText("Use phone instead")).toBeTruthy();
-      expect(screen.getByPlaceholderText("Email")).toBeTruthy();
-      expect(screen.queryByPlaceholderText("Phone Number")).toBeNull();
-    });
-  });
-
   // --- Email validation ---
 
   describe("Email validation", () => {
-    it("does not require email in default phone mode", async () => {
+    it("shows 'Email is required' when creating account with empty email", async () => {
       render(<RegisterContact />);
-
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
-      const createAccountButton = screen.getByText("Create Account");
-      await act(async () => {
-        fireEvent.press(createAccountButton);
-        await waitFor(() => {
-          expect(mockApiRegister).toHaveBeenCalled();
-        });
-      });
-
-      expect(mockApiRegister).toHaveBeenCalledWith(
-        expect.not.objectContaining({
-          email: expect.any(String),
-        })
-      );
-    });
-
-    it("shows 'Email is required' in email mode when creating account with empty email", async () => {
-      render(<RegisterContact />);
-      fireEvent.press(screen.getByText("Use email instead"));
 
       const createAccountButton = screen.getByText("Create Account");
       fireEvent.press(createAccountButton);
@@ -197,9 +120,8 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       expect(mockApiRegister).not.toHaveBeenCalled();
     });
 
-    it("shows 'Please enter a valid email address' error for invalid email in email mode", async () => {
+    it("shows 'Please enter a valid email address' error for invalid email", async () => {
       render(<RegisterContact />);
-      fireEvent.press(screen.getByText("Use email instead"));
 
       const emailInput = screen.getByPlaceholderText("Email");
       fireEvent.changeText(emailInput, "invalid-email");
@@ -214,7 +136,6 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
 
     it("accepts valid email addresses", async () => {
       render(<RegisterContact />);
-      fireEvent.press(screen.getByText("Use email instead"));
 
       const emailInput = screen.getByPlaceholderText("Email");
       fireEvent.changeText(emailInput, "test@example.com");
@@ -236,7 +157,6 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
 
     it("trims whitespace from email before validation", async () => {
       render(<RegisterContact />);
-      fireEvent.press(screen.getByText("Use email instead"));
 
       const emailInput = screen.getByPlaceholderText("Email");
       fireEvent.changeText(emailInput, "  test@example.com  ");
@@ -257,119 +177,11 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
     });
   });
 
-  // --- Phone number validation ---
-
-  describe("Phone number validation", () => {
-    it("shows 'Phone number is required' error when creating account with empty phone", async () => {
-      render(<RegisterContact />);
-
-      const createAccountButton = screen.getByText("Create Account");
-      fireEvent.press(createAccountButton);
-
-      await waitFor(() => {
-        expect(screen.getByText("Phone number is required")).toBeTruthy();
-      });
-
-      expect(mockApiRegister).not.toHaveBeenCalled();
-    });
-
-    it("shows 'Please enter a valid phone number' error for invalid phone", async () => {
-      render(<RegisterContact />);
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "123");
-
-      const createAccountButton = screen.getByText("Create Account");
-      fireEvent.press(createAccountButton);
-
-      await waitFor(() => {
-        expect(screen.getByText("Please enter a valid phone number")).toBeTruthy();
-      });
-
-      expect(mockApiRegister).not.toHaveBeenCalled();
-    });
-
-    it("does not require phone in email mode", async () => {
-      render(<RegisterContact />);
-
-      fireEvent.press(screen.getByText("Use email instead"));
-      fireEvent.changeText(screen.getByPlaceholderText("Email"), "test@example.com");
-
-      const createAccountButton = screen.getByText("Create Account");
-      await act(async () => {
-        fireEvent.press(createAccountButton);
-        await waitFor(() => {
-          expect(mockApiRegister).toHaveBeenCalled();
-        });
-      });
-
-      expect(mockApiRegister).toHaveBeenCalledWith(
-        expect.not.objectContaining({
-          phoneNumber: expect.any(String),
-        })
-      );
-    });
-
-    it("formats phone number as user types", () => {
-      render(<RegisterContact />);
-
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
-
-      // Phone should be formatted
-      expect(phoneInput.props.value).toBe("(812) 294-9840");
-    });
-
-    it("accepts valid phone numbers", async () => {
-      render(<RegisterContact />);
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
-
-      const createAccountButton = screen.getByText("Create Account");
-      await act(async () => {
-        fireEvent.press(createAccountButton);
-        await waitFor(() => {
-          expect(mockApiRegister).toHaveBeenCalled();
-        });
-      });
-
-      // Phone should be converted to E.164 format
-      expect(mockApiRegister).toHaveBeenCalledWith(
-        expect.objectContaining({
-          phoneNumber: "+18122949840",
-        })
-      );
-    });
-  });
-
   // --- API integration ---
 
   describe("API integration", () => {
-    it("calls register() API with phone-only data in default mode", async () => {
+    it("calls register() API with email data", async () => {
       render(<RegisterContact />);
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
-
-      const createAccountButton = screen.getByText("Create Account");
-      await act(async () => {
-        fireEvent.press(createAccountButton);
-        await waitFor(() => {
-          expect(mockApiRegister).toHaveBeenCalled();
-        });
-      });
-
-      expect(mockApiRegister).toHaveBeenCalledWith({
-        username: "testuser",
-        password: "ValidPass123!",
-        passwordConfirm: "ValidPass123!",
-        phoneNumber: "+18122949840",
-        firstName: "John",
-        lastName: "Doe",
-      });
-    });
-
-    it("calls register() API with email-only data in email mode", async () => {
-      render(<RegisterContact />);
-      fireEvent.press(screen.getByText("Use email instead"));
       fireEvent.changeText(screen.getByPlaceholderText("Email"), "test@example.com");
 
       const createAccountButton = screen.getByText("Create Account");
@@ -392,8 +204,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
 
     it("calls login() API after successful registration", async () => {
       render(<RegisterContact />);
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
+      fireEvent.changeText(screen.getByPlaceholderText("Email"), "test@example.com");
 
       const createAccountButton = screen.getByText("Create Account");
       await act(async () => {
@@ -414,8 +225,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
 
     it("calls authLogin() with tokens after successful login", async () => {
       render(<RegisterContact />);
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
+      fireEvent.changeText(screen.getByPlaceholderText("Email"), "test@example.com");
 
       const createAccountButton = screen.getByText("Create Account");
       await act(async () => {
@@ -434,8 +244,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
 
     it("navigates to /home after successful registration and login", async () => {
       render(<RegisterContact />);
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
+      fireEvent.changeText(screen.getByPlaceholderText("Email"), "test@example.com");
 
       const createAccountButton = screen.getByText("Create Account");
       await act(async () => {
@@ -457,8 +266,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockApiRegister.mockReturnValueOnce(registerPromise);
 
       const { UNSAFE_root } = render(<RegisterContact />);
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
+      fireEvent.changeText(screen.getByPlaceholderText("Email"), "test@example.com");
 
       const createAccountButton = screen.getByText("Create Account");
       fireEvent.press(createAccountButton);
@@ -487,8 +295,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockApiRegister.mockRejectedValueOnce(error);
 
       render(<RegisterContact />);
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
+      fireEvent.changeText(screen.getByPlaceholderText("Email"), "test@example.com");
 
       const createAccountButton = screen.getByText("Create Account");
       await act(async () => {
@@ -506,8 +313,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockApiRegister.mockRejectedValueOnce(error);
 
       render(<RegisterContact />);
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
+      fireEvent.changeText(screen.getByPlaceholderText("Email"), "test@example.com");
 
       const createAccountButton = screen.getByText("Create Account");
       await act(async () => {
@@ -547,7 +353,6 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockApiRegister.mockRejectedValueOnce(error);
 
       render(<RegisterContact />);
-      fireEvent.press(screen.getByText("Use email instead"));
       const emailInput = screen.getByPlaceholderText("Email");
       fireEvent.changeText(emailInput, "test@example.com");
 
@@ -561,33 +366,12 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       }, { timeout: 2000 });
     });
 
-    it("sets phone error when phone is already taken", async () => {
-      // Use error message that contains "phone" to match phone error condition
-      // Note: The code checks "username" || "already exists" first, so we need to avoid "already exists"
-      const error = new Error("This phone number is already registered");
-      mockApiRegister.mockRejectedValueOnce(error);
-
-      render(<RegisterContact />);
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
-
-      const createAccountButton = screen.getByText("Create Account");
-      await act(async () => {
-        fireEvent.press(createAccountButton);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText("An account with this phone number already exists")).toBeTruthy();
-      }, { timeout: 2000 });
-    });
-
     it("shows alert and navigates back when password error occurs", async () => {
       const error = new Error("Password does not meet requirements");
       mockApiRegister.mockRejectedValueOnce(error);
 
       render(<RegisterContact />);
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
+      fireEvent.changeText(screen.getByPlaceholderText("Email"), "test@example.com");
 
       const createAccountButton = screen.getByText("Create Account");
       await act(async () => {
@@ -626,8 +410,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockApiLogin.mockRejectedValueOnce(loginError);
 
       render(<RegisterContact />);
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
+      fireEvent.changeText(screen.getByPlaceholderText("Email"), "test@example.com");
 
       const createAccountButton = screen.getByText("Create Account");
       await act(async () => {
@@ -668,8 +451,7 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       mockParams = {};
 
       render(<RegisterContact />);
-      const phoneInput = screen.getByPlaceholderText("Phone Number");
-      fireEvent.changeText(phoneInput, "8122949840");
+      fireEvent.changeText(screen.getByPlaceholderText("Email"), "test@example.com");
 
       const createAccountButton = screen.getByText("Create Account");
       fireEvent.press(createAccountButton);

--- a/frontend/__tests__/register-contact.test.tsx
+++ b/frontend/__tests__/register-contact.test.tsx
@@ -367,6 +367,29 @@ describe("Register Contact Screen Step 3 (app/(auth)/register-contact.tsx)", () 
       });
     });
 
+    it("calls register() API with email-only data in email mode", async () => {
+      render(<RegisterContact />);
+      fireEvent.press(screen.getByText("Use email instead"));
+      fireEvent.changeText(screen.getByPlaceholderText("Email"), "test@example.com");
+
+      const createAccountButton = screen.getByText("Create Account");
+      await act(async () => {
+        fireEvent.press(createAccountButton);
+        await waitFor(() => {
+          expect(mockApiRegister).toHaveBeenCalled();
+        });
+      });
+
+      expect(mockApiRegister).toHaveBeenCalledWith({
+        username: "testuser",
+        password: "ValidPass123!",
+        passwordConfirm: "ValidPass123!",
+        email: "test@example.com",
+        firstName: "John",
+        lastName: "Doe",
+      });
+    });
+
     it("calls login() API after successful registration", async () => {
       render(<RegisterContact />);
       const phoneInput = screen.getByPlaceholderText("Phone Number");

--- a/frontend/app/(auth)/register-contact.tsx
+++ b/frontend/app/(auth)/register-contact.tsx
@@ -36,7 +36,19 @@ export default function RegisterContact() {
   const [emailError, setEmailError] = React.useState("");
   const [phoneNumber, setPhoneNumber] = React.useState("");
   const [phoneNumberError, setPhoneNumberError] = React.useState("");
+  const [contactMode, setContactMode] = React.useState<"phone" | "email">("phone");
   const [isLoading, setIsLoading] = React.useState(false);
+
+  const handleEmailChange = (text: string) => {
+    setEmail(text);
+    setEmailError("");
+  };
+
+  const handleContactModeToggle = () => {
+    setContactMode((current) => (current === "phone" ? "email" : "phone"));
+    setEmailError("");
+    setPhoneNumberError("");
+  };
 
   // Format phone number as user types (defaults to US format)
   const handlePhoneNumberChange = (text: string) => {
@@ -102,24 +114,25 @@ export default function RegisterContact() {
     // Validate inputs
     let hasErrors = false;
 
-    if (!email.trim()) {
+    const trimmedEmail = email.trim();
+    const hasEmail = trimmedEmail.length > 0;
+    const hasPhoneInput = phoneNumber.trim().length > 0;
+    const e164Phone = hasPhoneInput ? formatPhoneToE164(phoneNumber) : null;
+
+    if (contactMode === "email" && !hasEmail) {
       setEmailError("Email is required");
       hasErrors = true;
-    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) {
+    } else if (hasEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
       setEmailError("Please enter a valid email address");
       hasErrors = true;
     }
 
-    if (!phoneNumber.trim()) {
+    if (contactMode === "phone" && !hasPhoneInput) {
       setPhoneNumberError("Phone number is required");
       hasErrors = true;
-    } else {
-      // Validate and convert phone number to E.164 format
-      const e164Phone = formatPhoneToE164(phoneNumber);
-      if (!e164Phone) {
-        setPhoneNumberError("Please enter a valid phone number");
-        hasErrors = true;
-      }
+    } else if (hasPhoneInput && !e164Phone) {
+      setPhoneNumberError("Please enter a valid phone number");
+      hasErrors = true;
     }
 
     if (hasErrors) {
@@ -136,24 +149,20 @@ export default function RegisterContact() {
     setIsLoading(true);
 
     try {
-      // Convert phone number to E.164 format
-      const e164Phone = formatPhoneToE164(phoneNumber);
-      if (!e164Phone) {
-        setPhoneNumberError("Please enter a valid phone number");
-        setIsLoading(false);
-        return;
-      }
-
-      // Call register API with all data
-      await register({
+      const trimmedEmail = email.trim();
+      const e164Phone = phoneNumber.trim() ? formatPhoneToE164(phoneNumber) : null;
+      const registrationPayload = {
         username: params.username,
         password: params.password,
         passwordConfirm: params.password,
-        email: email.trim(),
-        phoneNumber: e164Phone, // Use E.164 formatted phone number
         firstName: params.firstName,
         lastName: params.lastName,
-      });
+        ...(trimmedEmail ? { email: trimmedEmail } : {}),
+        ...(e164Phone ? { phoneNumber: e164Phone } : {}),
+      };
+
+      // Call register API with all provided data
+      await register(registrationPayload);
 
       // Automatically log the user in after successful registration
       try {
@@ -293,45 +302,67 @@ export default function RegisterContact() {
             },
             accessibilityLabel: "Registration form step 2",
           },
-          "Step 3 of 3: Email & Contact"
+          "Step 3 of 3: Contact"
         ),
-        React.createElement(TextField, {
-          ref: emailRef,
-          value: email,
-          onChangeText: setEmail,
-          error: emailError,
-          autoCapitalize: "none",
-          autoComplete: "email",
-          keyboardType: "email-address",
-          returnKeyType: "next",
-          onSubmitEditing: () => {
-            phoneNumberRef.current?.focus();
+        contactMode === "email"
+          ? React.createElement(TextField, {
+              ref: emailRef,
+              value: email,
+              onChangeText: handleEmailChange,
+              error: emailError,
+              autoCapitalize: "none",
+              autoComplete: "email",
+              keyboardType: "email-address",
+              returnKeyType: "done",
+              onSubmitEditing: handleRegister,
+              placeholder: "Email",
+              accessibilityLabel: "Email",
+              accessibilityHint: "Enter your email address.",
+              style: {
+                width: "100%",
+                marginBottom: spacing.xs,
+              },
+            })
+          : React.createElement(TextField, {
+              ref: phoneNumberRef,
+              value: phoneNumber,
+              onChangeText: handlePhoneNumberChange,
+              error: phoneNumberError,
+              autoComplete: "tel",
+              keyboardType: "phone-pad",
+              returnKeyType: "done",
+              onSubmitEditing: handleRegister,
+              placeholder: "Phone Number",
+              accessibilityLabel: "Phone Number",
+              accessibilityHint: "Enter your phone number (e.g., (812) 294-9840). It will be automatically formatted.",
+              style: {
+                width: "100%",
+                marginBottom: spacing.xs,
+              },
+            }),
+        React.createElement(
+          Pressable,
+          {
+            onPress: handleContactModeToggle,
+            accessibilityRole: "button",
+            accessibilityLabel: contactMode === "phone" ? "Use email instead" : "Use phone instead",
+            style: {
+              alignSelf: "flex-start",
+              marginBottom: spacing.sm,
+              marginLeft: spacing.xs,
+            },
           },
-          placeholder: "Email",
-          accessibilityLabel: "Email",
-          accessibilityHint: "Enter your email address. Press next to move to phone number field.",
-          style: {
-            width: "100%",
-            marginBottom: spacing.md,
-          },
-        }),
-        React.createElement(TextField, {
-          ref: phoneNumberRef,
-          value: phoneNumber,
-          onChangeText: handlePhoneNumberChange,
-          error: phoneNumberError,
-          autoComplete: "tel",
-          keyboardType: "phone-pad",
-          returnKeyType: "done",
-          onSubmitEditing: handleRegister,
-          placeholder: "Phone Number",
-          accessibilityLabel: "Phone Number",
-          accessibilityHint: "Enter your phone number (e.g., (812) 294-9840). It will be automatically formatted.",
-          style: {
-            width: "100%",
-            marginBottom: spacing.md,
-          },
-        }),
+          React.createElement(
+            Text,
+            {
+              style: {
+                ...typography.label,
+                color: colors.primary,
+              },
+            },
+            contactMode === "phone" ? "Use email instead" : "Use phone instead"
+          )
+        ),
         React.createElement(Button, {
           onPress: handleRegister,
           title: "Create Account",

--- a/frontend/app/(auth)/register-contact.tsx
+++ b/frontend/app/(auth)/register-contact.tsx
@@ -1,15 +1,14 @@
 /**
- * Register Contact screen - Step 3: Email and Contact information
+ * Register Contact screen - Step 3: Email information
  *
- * This screen collects email and phone number to complete registration.
+ * This screen collects email to complete registration.
  * Users submit the registration from this screen and are automatically logged in.
  */
 
 import * as React from "react";
-import { View, Text, Alert, Pressable, Keyboard, TouchableWithoutFeedback, TextInput, ScrollView } from "react-native";
+import { Text, Alert, Keyboard, TouchableWithoutFeedback, TextInput, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter, useLocalSearchParams } from "expo-router";
-import { parsePhoneNumber, AsYouType } from "libphonenumber-js";
 import Button from "../../components/Button";
 import TextField from "../../components/TextField";
 import Label from "../../components/Label";
@@ -30,13 +29,9 @@ export default function RegisterContact() {
   }>();
 
   const emailRef = React.useRef<TextInput>(null);
-  const phoneNumberRef = React.useRef<TextInput>(null);
 
   const [email, setEmail] = React.useState("");
   const [emailError, setEmailError] = React.useState("");
-  const [phoneNumber, setPhoneNumber] = React.useState("");
-  const [phoneNumberError, setPhoneNumberError] = React.useState("");
-  const [contactMode, setContactMode] = React.useState<"phone" | "email">("phone");
   const [isLoading, setIsLoading] = React.useState(false);
 
   const handleEmailChange = (text: string) => {
@@ -44,98 +39,19 @@ export default function RegisterContact() {
     setEmailError("");
   };
 
-  const handleContactModeToggle = () => {
-    setContactMode((current) => (current === "phone" ? "email" : "phone"));
-    setEmailError("");
-    setPhoneNumberError("");
-  };
-
-  // Format phone number as user types (defaults to US format)
-  const handlePhoneNumberChange = (text: string) => {
-    // Extract only digits and + sign (for country codes)
-    // This allows natural deletion without formatting interference
-    // By always extracting digits first, deletion works naturally because:
-    // 1. User types/deletes -> TextInput gives us the new text
-    // 2. We extract digits from that text
-    // 3. We format those digits
-    // This way, deletion of any character (digit or formatting) works correctly
-    const digitsOnly = text.replace(/[^\d+]/g, "");
-    
-    // Use AsYouType formatter for natural formatting
-    // It will automatically format as user types: (812) 294-9840
-    // Pass only the digits to the formatter so it can format correctly
-    const formatter = new AsYouType("US"); // Default to US, but will auto-detect country code if + is present
-    const formatted = formatter.input(digitsOnly);
-    
-    setPhoneNumber(formatted);
-    setPhoneNumberError(""); // Clear error when user starts typing
-  };
-
-  // Convert phone number to E.164 format for API
-  const formatPhoneToE164 = (phone: string): string | null => {
-    if (!phone.trim()) {
-      return null;
-    }
-
-    try {
-      // Try to parse the phone number
-      const phoneNumber = parsePhoneNumber(phone, "US"); // Default to US if no country code
-      
-      if (phoneNumber && phoneNumber.isValid()) {
-        return phoneNumber.number; // Returns E.164 format (e.g., +18122949840)
-      }
-      
-      // If parsing fails, try to add US country code if it's a 10-digit number
-      const digitsOnly = phone.replace(/\D/g, "");
-      if (digitsOnly.length === 10) {
-        return `+1${digitsOnly}`;
-      }
-      
-      // If it starts with +, try to parse it
-      if (phone.startsWith("+")) {
-        const parsed = parsePhoneNumber(phone);
-        if (parsed && parsed.isValid()) {
-          return parsed.number;
-        }
-      }
-      
-      return null;
-    } catch (error) {
-      console.error("Phone number parsing error:", error);
-      return null;
-    }
-  };
-
   const handleRegister = async () => {
     // Clear previous errors
     setEmailError("");
-    setPhoneNumberError("");
 
     // Validate inputs
-    let hasErrors = false;
-
     const trimmedEmail = email.trim();
-    const hasEmail = trimmedEmail.length > 0;
-    const hasPhoneInput = phoneNumber.trim().length > 0;
-    const e164Phone = hasPhoneInput ? formatPhoneToE164(phoneNumber) : null;
-
-    if (contactMode === "email" && !hasEmail) {
+    if (!trimmedEmail) {
       setEmailError("Email is required");
-      hasErrors = true;
-    } else if (hasEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
+      return;
+    }
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
       setEmailError("Please enter a valid email address");
-      hasErrors = true;
-    }
-
-    if (contactMode === "phone" && !hasPhoneInput) {
-      setPhoneNumberError("Phone number is required");
-      hasErrors = true;
-    } else if (hasPhoneInput && !e164Phone) {
-      setPhoneNumberError("Please enter a valid phone number");
-      hasErrors = true;
-    }
-
-    if (hasErrors) {
       return;
     }
 
@@ -150,15 +66,13 @@ export default function RegisterContact() {
 
     try {
       const trimmedEmail = email.trim();
-      const e164Phone = phoneNumber.trim() ? formatPhoneToE164(phoneNumber) : null;
       const registrationPayload = {
         username: params.username,
         password: params.password,
         passwordConfirm: params.password,
         firstName: params.firstName,
         lastName: params.lastName,
-        ...(trimmedEmail ? { email: trimmedEmail } : {}),
-        ...(e164Phone ? { phoneNumber: e164Phone } : {}),
+        email: trimmedEmail,
       };
 
       // Call register API with all provided data
@@ -217,8 +131,6 @@ export default function RegisterContact() {
         );
       } else if (errorLower.includes("email") || errorLower.includes("already exists")) {
         setEmailError("An account with this email already exists");
-      } else if (errorLower.includes("phone") || errorLower.includes("already exists")) {
-        setPhoneNumberError("An account with this phone number already exists");
       } else if (errorLower.includes("password")) {
         // Password issue - need to go back to step 2
         Alert.alert(
@@ -302,67 +214,26 @@ export default function RegisterContact() {
             },
             accessibilityLabel: "Registration form step 2",
           },
-          "Step 3 of 3: Contact"
+          "Step 3 of 3: Email"
         ),
-        contactMode === "email"
-          ? React.createElement(TextField, {
-              ref: emailRef,
-              value: email,
-              onChangeText: handleEmailChange,
-              error: emailError,
-              autoCapitalize: "none",
-              autoComplete: "email",
-              keyboardType: "email-address",
-              returnKeyType: "done",
-              onSubmitEditing: handleRegister,
-              placeholder: "Email",
-              accessibilityLabel: "Email",
-              accessibilityHint: "Enter your email address.",
-              style: {
-                width: "100%",
-                marginBottom: spacing.xs,
-              },
-            })
-          : React.createElement(TextField, {
-              ref: phoneNumberRef,
-              value: phoneNumber,
-              onChangeText: handlePhoneNumberChange,
-              error: phoneNumberError,
-              autoComplete: "tel",
-              keyboardType: "phone-pad",
-              returnKeyType: "done",
-              onSubmitEditing: handleRegister,
-              placeholder: "Phone Number",
-              accessibilityLabel: "Phone Number",
-              accessibilityHint: "Enter your phone number (e.g., (812) 294-9840). It will be automatically formatted.",
-              style: {
-                width: "100%",
-                marginBottom: spacing.xs,
-              },
-            }),
-        React.createElement(
-          Pressable,
-          {
-            onPress: handleContactModeToggle,
-            accessibilityRole: "button",
-            accessibilityLabel: contactMode === "phone" ? "Use email instead" : "Use phone instead",
-            style: {
-              alignSelf: "flex-start",
-              marginBottom: spacing.sm,
-              marginLeft: spacing.xs,
-            },
+        React.createElement(TextField, {
+          ref: emailRef,
+          value: email,
+          onChangeText: handleEmailChange,
+          error: emailError,
+          autoCapitalize: "none",
+          autoComplete: "email",
+          keyboardType: "email-address",
+          returnKeyType: "done",
+          onSubmitEditing: handleRegister,
+          placeholder: "Email",
+          accessibilityLabel: "Email",
+          accessibilityHint: "Enter your email address.",
+          style: {
+            width: "100%",
+            marginBottom: spacing.xs,
           },
-          React.createElement(
-            Text,
-            {
-              style: {
-                ...typography.label,
-                color: colors.primary,
-              },
-            },
-            contactMode === "phone" ? "Use email instead" : "Use phone instead"
-          )
-        ),
+        }),
         React.createElement(Button, {
           onPress: handleRegister,
           title: "Create Account",

--- a/frontend/services/__tests__/api.test.ts
+++ b/frontend/services/__tests__/api.test.ts
@@ -260,12 +260,131 @@ describe("register", () => {
       expect.objectContaining({
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(userData),
       })
     );
+    const registerRequest = (global.fetch as jest.Mock).mock.calls[0][1];
+    expect(JSON.parse(registerRequest.body)).toEqual(userData);
 
     // Verify the response
     expect(result).toEqual(mockResponse);
+  });
+
+  it("sends phone-only payload when email is omitted", async () => {
+    const mockResponse: RegisterResponse = {
+      message: "User registered successfully",
+      username: "testuser",
+    };
+
+    const userData: RegisterRequest = {
+      username: "testuser",
+      password: "password123",
+      passwordConfirm: "password123",
+      phoneNumber: "+1234567890",
+      firstName: "Test",
+      lastName: "User",
+    };
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    await apiModule.register(userData);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://test-api.example.com/register",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const registerRequest = (global.fetch as jest.Mock).mock.calls[0][1];
+    expect(JSON.parse(registerRequest.body)).toEqual({
+      username: "testuser",
+      password: "password123",
+      passwordConfirm: "password123",
+      firstName: "Test",
+      lastName: "User",
+      phoneNumber: "+1234567890",
+    });
+  });
+
+  it("sends email-only payload when phone number is omitted", async () => {
+    const mockResponse: RegisterResponse = {
+      message: "User registered successfully",
+      username: "testuser",
+    };
+
+    const userData: RegisterRequest = {
+      username: "testuser",
+      password: "password123",
+      passwordConfirm: "password123",
+      email: "test@example.com",
+      firstName: "Test",
+      lastName: "User",
+    };
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    await apiModule.register(userData);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://test-api.example.com/register",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const registerRequest = (global.fetch as jest.Mock).mock.calls[0][1];
+    expect(JSON.parse(registerRequest.body)).toEqual({
+      username: "testuser",
+      password: "password123",
+      passwordConfirm: "password123",
+      firstName: "Test",
+      lastName: "User",
+      email: "test@example.com",
+    });
+  });
+
+  it("omits blank optional contact fields from payload", async () => {
+    const mockResponse: RegisterResponse = {
+      message: "User registered successfully",
+      username: "testuser",
+    };
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    await apiModule.register({
+      username: "testuser",
+      password: "password123",
+      passwordConfirm: "password123",
+      email: "   ",
+      phoneNumber: "",
+      firstName: "Test",
+      lastName: "User",
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://test-api.example.com/register",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const registerRequest = (global.fetch as jest.Mock).mock.calls[0][1];
+    expect(JSON.parse(registerRequest.body)).toEqual({
+      username: "testuser",
+      password: "password123",
+      passwordConfirm: "password123",
+      firstName: "Test",
+      lastName: "User",
+    });
   });
 
   it("throws with API error message on failure", async () => {

--- a/frontend/services/__tests__/api.test.ts
+++ b/frontend/services/__tests__/api.test.ts
@@ -242,7 +242,6 @@ describe("register", () => {
       password: "password123",
       passwordConfirm: "password123",
       email: "test@example.com",
-      phoneNumber: "+1234567890",
       firstName: "Test",
       lastName: "User",
     };
@@ -269,87 +268,7 @@ describe("register", () => {
     expect(result).toEqual(mockResponse);
   });
 
-  it("sends phone-only payload when email is omitted", async () => {
-    const mockResponse: RegisterResponse = {
-      message: "User registered successfully",
-      username: "testuser",
-    };
-
-    const userData: RegisterRequest = {
-      username: "testuser",
-      password: "password123",
-      passwordConfirm: "password123",
-      phoneNumber: "+1234567890",
-      firstName: "Test",
-      lastName: "User",
-    };
-
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockResponse,
-    });
-
-    await apiModule.register(userData);
-
-    expect(global.fetch).toHaveBeenCalledWith(
-      "https://test-api.example.com/register",
-      expect.objectContaining({
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-      })
-    );
-    const registerRequest = (global.fetch as jest.Mock).mock.calls[0][1];
-    expect(JSON.parse(registerRequest.body)).toEqual({
-      username: "testuser",
-      password: "password123",
-      passwordConfirm: "password123",
-      firstName: "Test",
-      lastName: "User",
-      phoneNumber: "+1234567890",
-    });
-  });
-
-  it("sends email-only payload when phone number is omitted", async () => {
-    const mockResponse: RegisterResponse = {
-      message: "User registered successfully",
-      username: "testuser",
-    };
-
-    const userData: RegisterRequest = {
-      username: "testuser",
-      password: "password123",
-      passwordConfirm: "password123",
-      email: "test@example.com",
-      firstName: "Test",
-      lastName: "User",
-    };
-
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockResponse,
-    });
-
-    await apiModule.register(userData);
-
-    expect(global.fetch).toHaveBeenCalledWith(
-      "https://test-api.example.com/register",
-      expect.objectContaining({
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-      })
-    );
-    const registerRequest = (global.fetch as jest.Mock).mock.calls[0][1];
-    expect(JSON.parse(registerRequest.body)).toEqual({
-      username: "testuser",
-      password: "password123",
-      passwordConfirm: "password123",
-      firstName: "Test",
-      lastName: "User",
-      email: "test@example.com",
-    });
-  });
-
-  it("omits blank optional contact fields from payload", async () => {
+  it("trims email before sending payload", async () => {
     const mockResponse: RegisterResponse = {
       message: "User registered successfully",
       username: "testuser",
@@ -364,8 +283,7 @@ describe("register", () => {
       username: "testuser",
       password: "password123",
       passwordConfirm: "password123",
-      email: "   ",
-      phoneNumber: "",
+      email: "  test@example.com  ",
       firstName: "Test",
       lastName: "User",
     });
@@ -384,7 +302,8 @@ describe("register", () => {
       passwordConfirm: "password123",
       firstName: "Test",
       lastName: "User",
-    });
+      email: "test@example.com",
+    }); 
   });
 
   it("throws with API error message on failure", async () => {
@@ -401,7 +320,6 @@ describe("register", () => {
         password: "password123",
         passwordConfirm: "password123",
         email: "test@example.com",
-        phoneNumber: "+1234567890",
         firstName: "Test",
         lastName: "User",
       })
@@ -422,7 +340,6 @@ describe("register", () => {
         password: "password123",
         passwordConfirm: "password123",
         email: "test@example.com",
-        phoneNumber: "+1234567890",
         firstName: "Test",
         lastName: "User",
       })
@@ -448,7 +365,6 @@ describe("register", () => {
         password: "password123",
         passwordConfirm: "password123",
         email: "test@example.com",
-        phoneNumber: "+1234567890",
         firstName: "Test",
         lastName: "User",
       })
@@ -468,7 +384,6 @@ describe("register", () => {
         password: "password123",
         passwordConfirm: "password123",
         email: "test@example.com",
-        phoneNumber: "+1234567890",
         firstName: "Test",
         lastName: "User",
       });
@@ -490,7 +405,6 @@ describe("register", () => {
         password: "password123",
         passwordConfirm: "password123",
         email: "test@example.com",
-        phoneNumber: "+1234567890",
         firstName: "Test",
         lastName: "User",
       })
@@ -506,7 +420,6 @@ describe("register", () => {
         password: "password123",
         passwordConfirm: "password123",
         email: "test@example.com",
-        phoneNumber: "+1234567890",
         firstName: "Test",
         lastName: "User",
       })
@@ -525,7 +438,6 @@ describe("register", () => {
         password: "password123",
         passwordConfirm: "password123",
         email: "test@example.com",
-        phoneNumber: "+1234567890",
         firstName: "Test",
         lastName: "User",
       })

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -60,8 +60,8 @@ export interface RegisterRequest {
   username: string;
   password: string;
   passwordConfirm: string;
-  email: string;
-  phoneNumber: string;
+  email?: string;
+  phoneNumber?: string;
   firstName: string;
   lastName: string;
 }

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -60,8 +60,7 @@ export interface RegisterRequest {
   username: string;
   password: string;
   passwordConfirm: string;
-  email?: string;
-  phoneNumber?: string;
+  email: string;
   firstName: string;
   lastName: string;
 }
@@ -163,16 +162,14 @@ export async function refreshToken(refreshToken: string): Promise<RefreshTokenRe
 export async function register(userData: RegisterRequest): Promise<RegisterResponse> {
   const base = requireApiUrl();
   const url = `${base}/register`;
-  const trimmedEmail = userData.email?.trim();
-  const trimmedPhoneNumber = userData.phoneNumber?.trim();
+  const trimmedEmail = userData.email.trim();
   const requestPayload: RegisterRequest = {
     username: userData.username,
     password: userData.password,
     passwordConfirm: userData.passwordConfirm,
     firstName: userData.firstName,
     lastName: userData.lastName,
-    ...(trimmedEmail ? { email: trimmedEmail } : {}),
-    ...(trimmedPhoneNumber ? { phoneNumber: trimmedPhoneNumber } : {}),
+    email: trimmedEmail,
   };
   
   try {

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -163,6 +163,17 @@ export async function refreshToken(refreshToken: string): Promise<RefreshTokenRe
 export async function register(userData: RegisterRequest): Promise<RegisterResponse> {
   const base = requireApiUrl();
   const url = `${base}/register`;
+  const trimmedEmail = userData.email?.trim();
+  const trimmedPhoneNumber = userData.phoneNumber?.trim();
+  const requestPayload: RegisterRequest = {
+    username: userData.username,
+    password: userData.password,
+    passwordConfirm: userData.passwordConfirm,
+    firstName: userData.firstName,
+    lastName: userData.lastName,
+    ...(trimmedEmail ? { email: trimmedEmail } : {}),
+    ...(trimmedPhoneNumber ? { phoneNumber: trimmedPhoneNumber } : {}),
+  };
   
   try {
     const response = await fetch(url, {
@@ -170,7 +181,7 @@ export async function register(userData: RegisterRequest): Promise<RegisterRespo
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(userData),
+      body: JSON.stringify(requestPayload),
     });
 
     let data;


### PR DESCRIPTION
## PR Summary

This PR updates account registration to **email-only signup** across frontend and backend flows. It removes phone-number-first assumptions in request validation, payload construction, and related tests/docs so registration/auth behavior is consistent end-to-end.

### How this fits the project

Stride’s goal is low-friction, reliable onboarding for our user base. Requiring phone verification added unnecessary complexity and user friction without a clear product need (real feedback from deployment/mid-semester demo).  This change aligns signup with that goal by making email the single required identifier while keeping auth secure and test-covered.

### Why this change

- We do not currently have a strong product reason to require phone numbers.
- AWS SMS-based phone verification is outside the free tier and adds ongoing cost.
- Email-only signup reduces barriers during registration and improves usability.

### Relationship to other PRs / dependencies

- This PR closes **#254** (update account creation requirements).
- It is a **cross-layer integration change** (frontend + backend + tests + docs)
- It does not introduce a hard dependency on another open PR; it builds on the existing auth infrastructure already in `main`.

### Files changed (high-level)

- Frontend registration typing/payload logic updated for email-only flows.
- Backend validation and Cognito attribute handling updated to require email-only behavior.
- Unit/integration tests updated to cover expected email-only scenarios and guard regressions.
- Documentation updated to reflect the new registration contract.
