### PR TITLE
Feature/112 auth pass change

### DIFF
--- a/aws_resources/backend/src/main/kotlin/com/handlers/AuthHandler.kt
+++ b/aws_resources/backend/src/main/kotlin/com/handlers/AuthHandler.kt
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.cognitoidentityprovider.model.InitiateAut
 import software.amazon.awssdk.services.cognitoidentityprovider.model.InitiateAuthResponse
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AuthFlowType
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AuthenticationResultType
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ChangePasswordRequest as CognitoChangePasswordRequest
 import software.amazon.awssdk.services.cognitoidentityprovider.model.CognitoIdentityProviderException
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminCreateUserRequest
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminSetUserPasswordRequest
@@ -49,6 +50,7 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
             path == "/register" && method == "POST" -> handleRegister(input, context)
             path == "/register/check-username" && method == "GET" -> handleCheckUsername(input, context)
             path == "/register/check-email" && method == "GET" -> handleCheckEmail(input, context)
+            path == "/password/change" && method == "POST" -> handleChangePassword(input, context)
             else -> createErrorResponse(404, "Not Found")
         }
 
@@ -689,6 +691,126 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
         }
     }
 
+    private fun handleChangePassword(
+        input: APIGatewayProxyRequestEvent,
+        context: Context,
+    ): APIGatewayProxyResponseEvent {
+        context.logger.log("Handling change password request")
+
+        try {
+            val body = input.body ?: return createErrorResponse(400, "Request body is required")
+            val authorizationHeader = getAuthorizationHeader(input)
+                ?: return createErrorResponse(401, "Authorization header is required")
+            val accessToken = extractBearerToken(authorizationHeader)
+                ?: return createErrorResponse(401, "Authorization header must use Bearer token")
+
+            val request = try {
+                mapper.readValue<ChangePasswordRequest>(body)
+            } catch (e: Exception) {
+                context.logger.log("ERROR: Failed to parse request body: ${e.message}")
+                return createErrorResponse(
+                    400,
+                    "Invalid request format. Expected JSON with currentPassword, newPassword, and newPasswordConfirm"
+                )
+            }
+
+            val currentPassword = request.currentPassword?.trim()
+            val newPassword = request.newPassword?.trim()
+            val newPasswordConfirm = request.newPasswordConfirm?.trim()
+
+            if (currentPassword.isNullOrEmpty() || newPassword.isNullOrEmpty() || newPasswordConfirm.isNullOrEmpty()) {
+                return createErrorResponse(400, "Current password, new password, and password confirmation are required")
+            }
+
+            if (newPassword != newPasswordConfirm) {
+                return createErrorResponse(400, "Passwords do not match")
+            }
+
+            if (newPassword == currentPassword) {
+                return createErrorResponse(400, "New password must be different from current password")
+            }
+
+            val changePasswordRequest = CognitoChangePasswordRequest.builder()
+                .accessToken(accessToken)
+                .previousPassword(currentPassword)
+                .proposedPassword(newPassword)
+                .build()
+
+            cognitoClient.changePassword(changePasswordRequest)
+
+            val responseBody = mapper.writeValueAsString(
+                mapOf("message" to "Password changed successfully")
+            )
+            return APIGatewayProxyResponseEvent()
+                .withStatusCode(200)
+                .withBody(responseBody)
+                .withHeaders(mapOf("Content-Type" to "application/json"))
+        } catch (e: CognitoIdentityProviderException) {
+            context.logger.log("ERROR: Cognito password change failed: ${e.message}")
+
+            val errorCode = e.awsErrorDetails()?.errorCode()
+            val normalizedMessage = "${e.awsErrorDetails()?.errorMessage() ?: e.message ?: ""}".lowercase()
+            val userFriendlyMessage = parseCognitoError(e)
+
+            val statusCode: Int
+            val message: String
+
+            when (errorCode) {
+                "InvalidPasswordException" -> {
+                    statusCode = 400
+                    message = userFriendlyMessage
+                }
+                "TooManyRequestsException", "LimitExceededException" -> {
+                    statusCode = 429
+                    message = userFriendlyMessage
+                }
+                "NotAuthorizedException" -> {
+                    val tokenError = normalizedMessage.contains("token") ||
+                        normalizedMessage.contains("expired") ||
+                        normalizedMessage.contains("invalid access token") ||
+                        normalizedMessage.contains("access token")
+                    if (tokenError) {
+                        statusCode = 401
+                        message = "Invalid or expired access token"
+                    } else {
+                        statusCode = 400
+                        message = "Current password is incorrect"
+                    }
+                }
+                else -> {
+                    statusCode = 400
+                    message = userFriendlyMessage
+                }
+            }
+
+            return createErrorResponse(statusCode, message)
+        } catch (e: Exception) {
+            context.logger.log("ERROR: Unexpected error during password change: ${e.message}")
+            e.printStackTrace()
+            return createErrorResponse(500, "Internal server error")
+        }
+    }
+
+    private fun getAuthorizationHeader(input: APIGatewayProxyRequestEvent): String? {
+        return input.headers
+            ?.entries
+            ?.firstOrNull { it.key.equals("Authorization", ignoreCase = true) }
+            ?.value
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun extractBearerToken(authorizationHeader: String): String? {
+        if (!authorizationHeader.startsWith("Bearer ", ignoreCase = true)) {
+            return null
+        }
+
+        return authorizationHeader
+            .substringAfter(" ", "")
+            .trim()
+            .takeIf { it.isNotEmpty() }
+    }
+
     // Data class for login request
     private data class LoginRequest(
         val username: String?,
@@ -703,5 +825,12 @@ class AuthHandler : RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyR
         val email: String?,
         val firstName: String?,
         val lastName: String?
+    )
+
+    // Data class for change password request
+    private data class ChangePasswordRequest(
+        val currentPassword: String?,
+        val newPassword: String?,
+        val newPasswordConfirm: String?,
     )
 }

--- a/aws_resources/backend/src/test/kotlin/com/handlers/AuthHandlerTest.kt
+++ b/aws_resources/backend/src/test/kotlin/com/handlers/AuthHandlerTest.kt
@@ -270,6 +270,181 @@ class AuthHandlerTest {
         }
     }
 
+    private fun createChangePasswordEvent(
+        currentPassword: String = "CurrentPass123!",
+        newPassword: String = "NewPass123!",
+        newPasswordConfirm: String = "NewPass123!",
+        authorizationHeader: String? = "Bearer test-access-token",
+    ): APIGatewayProxyRequestEvent {
+        return APIGatewayProxyRequestEvent().apply {
+            httpMethod = "POST"
+            path = "/password/change"
+            body = """{"currentPassword":"$currentPassword","newPassword":"$newPassword","newPasswordConfirm":"$newPasswordConfirm"}"""
+            headers = if (authorizationHeader == null) {
+                null
+            } else {
+                mapOf("Authorization" to authorizationHeader)
+            }
+        }
+    }
+
+    // Change password validation tests
+
+    @Test
+    @DisplayName("Change password with missing body returns 400")
+    fun `change password missing body returns 400`() {
+        // Given
+        val event = APIGatewayProxyRequestEvent().apply {
+            httpMethod = "POST"
+            path = "/password/change"
+            body = null
+            headers = mapOf("Authorization" to "Bearer test-access-token")
+        }
+
+        // When
+        val response = handler.handleRequest(event, mockContext)
+
+        // Then
+        assertEquals(400, response.statusCode)
+        val responseBody = response.body
+        assertNotNull(responseBody)
+        assertTrue(responseBody!!.contains("error"))
+        assertTrue(responseBody.contains("Request body is required"))
+    }
+
+    @Test
+    @DisplayName("Change password with invalid JSON returns 400")
+    fun `change password invalid JSON returns 400`() {
+        // Given
+        val event = APIGatewayProxyRequestEvent().apply {
+            httpMethod = "POST"
+            path = "/password/change"
+            body = "invalid-json"
+            headers = mapOf("Authorization" to "Bearer test-access-token")
+        }
+
+        // When
+        val response = handler.handleRequest(event, mockContext)
+
+        // Then
+        assertEquals(400, response.statusCode)
+        val responseBody = response.body
+        assertNotNull(responseBody)
+        assertTrue(responseBody!!.contains("error"))
+        assertTrue(responseBody.contains("Invalid request format"))
+    }
+
+    @Test
+    @DisplayName("Change password with missing authorization header returns 401")
+    fun `change password missing authorization header returns 401`() {
+        // Given
+        val event = createChangePasswordEvent(authorizationHeader = null)
+
+        // When
+        val response = handler.handleRequest(event, mockContext)
+
+        // Then
+        assertEquals(401, response.statusCode)
+        val responseBody = response.body
+        assertNotNull(responseBody)
+        assertTrue(responseBody!!.contains("error"))
+        assertTrue(responseBody.contains("Authorization header is required"))
+    }
+
+    @Test
+    @DisplayName("Change password with invalid authorization format returns 401")
+    fun `change password invalid authorization format returns 401`() {
+        // Given
+        val event = createChangePasswordEvent(authorizationHeader = "Basic abc123")
+
+        // When
+        val response = handler.handleRequest(event, mockContext)
+
+        // Then
+        assertEquals(401, response.statusCode)
+        val responseBody = response.body
+        assertNotNull(responseBody)
+        assertTrue(responseBody!!.contains("error"))
+        assertTrue(responseBody.contains("Authorization header must use Bearer token"))
+    }
+
+    @Test
+    @DisplayName("Change password with missing bearer token returns 401")
+    fun `change password missing bearer token returns 401`() {
+        // Given
+        val event = createChangePasswordEvent(authorizationHeader = "Bearer   ")
+
+        // When
+        val response = handler.handleRequest(event, mockContext)
+
+        // Then
+        assertEquals(401, response.statusCode)
+        val responseBody = response.body
+        assertNotNull(responseBody)
+        assertTrue(responseBody!!.contains("error"))
+        assertTrue(responseBody.contains("Authorization header must use Bearer token"))
+    }
+
+    @Test
+    @DisplayName("Change password with missing required fields returns 400")
+    fun `change password missing required fields returns 400`() {
+        // Given
+        val event = APIGatewayProxyRequestEvent().apply {
+            httpMethod = "POST"
+            path = "/password/change"
+            body = """{"currentPassword":"CurrentPass123!","newPassword":"NewPass123!"}"""
+            headers = mapOf("Authorization" to "Bearer test-access-token")
+        }
+
+        // When
+        val response = handler.handleRequest(event, mockContext)
+
+        // Then
+        assertEquals(400, response.statusCode)
+        val responseBody = response.body
+        assertNotNull(responseBody)
+        assertTrue(responseBody!!.contains("error"))
+        assertTrue(responseBody.contains("required"))
+    }
+
+    @Test
+    @DisplayName("Change password with mismatched passwords returns 400")
+    fun `change password mismatched passwords returns 400`() {
+        // Given
+        val event = createChangePasswordEvent(newPasswordConfirm = "DifferentPass123!")
+
+        // When
+        val response = handler.handleRequest(event, mockContext)
+
+        // Then
+        assertEquals(400, response.statusCode)
+        val responseBody = response.body
+        assertNotNull(responseBody)
+        assertTrue(responseBody!!.contains("error"))
+        assertTrue(responseBody.contains("Passwords do not match"))
+    }
+
+    @Test
+    @DisplayName("Change password with same current and new password returns 400")
+    fun `change password same current and new password returns 400`() {
+        // Given
+        val event = createChangePasswordEvent(
+            currentPassword = "SamePass123!",
+            newPassword = "SamePass123!",
+            newPasswordConfirm = "SamePass123!",
+        )
+
+        // When
+        val response = handler.handleRequest(event, mockContext)
+
+        // Then
+        assertEquals(400, response.statusCode)
+        val responseBody = response.body
+        assertNotNull(responseBody)
+        assertTrue(responseBody!!.contains("error"))
+        assertTrue(responseBody.contains("New password must be different from current password"))
+    }
+
     // Registration tests
 
     @Test

--- a/aws_resources/backend/tests/integration/test_login_api.py
+++ b/aws_resources/backend/tests/integration/test_login_api.py
@@ -178,3 +178,83 @@ def test_invalid_endpoint(api_base_url):
         data = response.json()
         assert "error" in data
         assert "not found" in data["error"].lower()
+
+
+def test_change_password_flow(api_base_url, test_user_credentials):
+    """Test register -> login -> change password -> login with new password."""
+    # Register a user
+    register_response = requests.post(
+        f"{api_base_url}/register",
+        json={
+            "username": test_user_credentials["username"],
+            "password": test_user_credentials["password"],
+            "passwordConfirm": test_user_credentials["passwordConfirm"],
+            "email": test_user_credentials["email"],
+            "firstName": test_user_credentials["firstName"],
+            "lastName": test_user_credentials["lastName"],
+        },
+        headers={"Content-Type": "application/json"},
+        timeout=10,
+    )
+    assert register_response.status_code == 201, (
+        f"Expected 201, got {register_response.status_code}: {register_response.text}"
+    )
+
+    # Login with original password to get access token
+    login_response = requests.post(
+        f"{api_base_url}/login",
+        json={
+            "username": test_user_credentials["username"],
+            "password": test_user_credentials["password"],
+        },
+        headers={"Content-Type": "application/json"},
+        timeout=10,
+    )
+    assert login_response.status_code == 200, (
+        f"Expected 200, got {login_response.status_code}: {login_response.text}"
+    )
+    access_token = login_response.json().get("accessToken")
+    assert access_token, "Expected accessToken in login response"
+
+    # Change password using access token
+    new_password = "NewPass123!"
+    change_password_response = requests.post(
+        f"{api_base_url}/password/change",
+        json={
+            "currentPassword": test_user_credentials["password"],
+            "newPassword": new_password,
+            "newPasswordConfirm": new_password,
+        },
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {access_token}",
+        },
+        timeout=10,
+    )
+    assert change_password_response.status_code == 200, (
+        f"Expected 200, got {change_password_response.status_code}: {change_password_response.text}"
+    )
+    change_data = change_password_response.json()
+    assert "message" in change_data
+    assert change_data["message"] == "Password changed successfully"
+
+    # Login with the new password
+    login_new_password_response = requests.post(
+        f"{api_base_url}/login",
+        json={
+            "username": test_user_credentials["username"],
+            "password": new_password,
+        },
+        headers={"Content-Type": "application/json"},
+        timeout=10,
+    )
+    assert login_new_password_response.status_code == 200, (
+        "Expected 200 login with new password, got "
+        f"{login_new_password_response.status_code}: {login_new_password_response.text}"
+    )
+    login_new_data = login_new_password_response.json()
+    assert "accessToken" in login_new_data
+    assert "idToken" in login_new_data
+    assert "refreshToken" in login_new_data
+    assert "expiresIn" in login_new_data
+    assert "tokenType" in login_new_data

--- a/aws_resources/cdk/cdk_stack.py
+++ b/aws_resources/cdk/cdk_stack.py
@@ -176,7 +176,8 @@ class CdkStack(Stack):
             "cognito-idp:AdminCreateUser",
             "cognito-idp:AdminSetUserPassword",
             "cognito-idp:AdminDeleteUser",  # For cleanup on registration failure
-            "cognito-idp:ListUsers"  # For checking duplicate email/phone
+            "cognito-idp:ListUsers",  # For checking duplicate email/phone
+            "cognito-idp:ChangePassword",
         )
 
         # Add Cognito configuration to Lambda environment
@@ -211,6 +212,10 @@ class CdkStack(Stack):
         check_username.add_method("GET", integration=apigw.LambdaIntegration(auth_handler))
         check_email = register.add_resource("check-email")
         check_email.add_method("GET", integration=apigw.LambdaIntegration(auth_handler))
+
+        password = api.root.add_resource("password")
+        change = password.add_resource("change")
+        change.add_method("POST", integration=apigw.LambdaIntegration(auth_handler))
 
         search = api.root.add_resource("search")
         search.add_method("GET", integration=apigw.LambdaIntegration(static_navigation_handler))

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -681,11 +681,11 @@ paths:
         - Authentication
       summary: Change password (authenticated)
       description: |
-        **⚠️ NOT IMPLEMENTED YET**
-        
         Changes the authenticated user's password. Requires a valid access token.
         Uses Cognito's `ChangePassword` API.
       operationId: changePassword
+      security:
+        - BearerAuth: []
       requestBody:
         required: true
         content:

--- a/frontend/__tests__/change-password.test.tsx
+++ b/frontend/__tests__/change-password.test.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+import { Alert } from "react-native";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import ChangePasswordScreen from "../app/(tabs)/settings/change-password";
+
+const mockBack = jest.fn();
+const mockChangePassword = jest.fn();
+const mockLogout = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({
+    back: mockBack,
+  }),
+  useSegments: () => [],
+}));
+
+jest.mock("../services/api", () => ({
+  changePassword: (...args: any[]) => mockChangePassword(...args),
+}));
+
+jest.mock("../contexts/AuthContext", () => ({
+  useAuth: () => ({
+    logout: mockLogout,
+  }),
+}));
+
+const alertSpy = jest.spyOn(Alert, "alert");
+
+describe("Change Password Screen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders key form fields and actions", () => {
+    render(<ChangePasswordScreen />);
+
+    expect(screen.getByText("Change Password")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Current Password")).toBeTruthy();
+    expect(screen.getByPlaceholderText("New Password")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Confirm New Password")).toBeTruthy();
+    expect(screen.getByText("Save Password")).toBeTruthy();
+    expect(screen.getByText("Cancel")).toBeTruthy();
+  });
+
+  it("shows validation errors when submitting empty form", async () => {
+    render(<ChangePasswordScreen />);
+
+    fireEvent.press(screen.getByText("Save Password"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Current password is required")).toBeTruthy();
+      expect(screen.getByText("New password is required")).toBeTruthy();
+      expect(screen.getByText("Password confirmation is required")).toBeTruthy();
+    });
+
+    expect(mockChangePassword).not.toHaveBeenCalled();
+  });
+
+  it("submits valid payload and navigates back after success", async () => {
+    mockChangePassword.mockResolvedValueOnce({
+      message: "Password changed successfully",
+    });
+
+    render(<ChangePasswordScreen />);
+
+    fireEvent.changeText(screen.getByPlaceholderText("Current Password"), "OldPass123!");
+    fireEvent.changeText(screen.getByPlaceholderText("New Password"), "NewPass123!");
+    fireEvent.changeText(screen.getByPlaceholderText("Confirm New Password"), "NewPass123!");
+    fireEvent.press(screen.getByText("Save Password"));
+
+    await waitFor(() => {
+      expect(mockChangePassword).toHaveBeenCalledWith({
+        currentPassword: "OldPass123!",
+        newPassword: "NewPass123!",
+        newPasswordConfirm: "NewPass123!",
+      });
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith("Success", "Password changed successfully", [
+      { text: "OK", onPress: expect.any(Function) },
+    ]);
+
+    const okAction = alertSpy.mock.calls[0][2]?.[0];
+    if (okAction && okAction.onPress) {
+      okAction.onPress();
+    }
+    expect(mockBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs out when API indicates session expiry", async () => {
+    mockChangePassword.mockRejectedValueOnce(
+      new Error("Your session has expired. Please log in again.")
+    );
+
+    render(<ChangePasswordScreen />);
+
+    fireEvent.changeText(screen.getByPlaceholderText("Current Password"), "OldPass123!");
+    fireEvent.changeText(screen.getByPlaceholderText("New Password"), "NewPass123!");
+    fireEvent.changeText(screen.getByPlaceholderText("Confirm New Password"), "NewPass123!");
+    fireEvent.press(screen.getByText("Save Password"));
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalledTimes(1);
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith("Session expired", "Please log in again.");
+  });
+});

--- a/frontend/app/(auth)/register-credentials.tsx
+++ b/frontend/app/(auth)/register-credentials.tsx
@@ -14,6 +14,7 @@ import Button from "../../components/Button";
 import TextField from "../../components/TextField";
 import Label from "../../components/Label";
 import ValidationIndicator, { ValidationStatus } from "../../components/ValidationIndicator";
+import { checkPasswordRequirements, isPasswordValid } from "../../utils/passwordPolicy";
 import { spacing } from "../../theme/spacing";
 import { typography } from "../../theme/typography";
 import { colors } from "../../theme/colors";
@@ -47,27 +48,12 @@ export default function RegisterCredentials() {
   const [focusedField, setFocusedField] = React.useState<"username" | "password" | "passwordConfirm" | null>(null);
   const [hasScrolled, setHasScrolled] = React.useState(false);
 
-  // Password requirements checking
-  const checkPasswordRequirements = (pwd: string) => {
-    return {
-      minLength: pwd.length >= 8,
-      hasUpperCase: /[A-Z]/.test(pwd),
-      hasLowerCase: /[a-z]/.test(pwd),
-      hasNumber: /[0-9]/.test(pwd),
-      hasSpecialChar: /[^A-Za-z0-9]/.test(pwd),
-    };
-  };
-
   const passwordRequirements = React.useMemo(() => checkPasswordRequirements(password), [password]);
   const passwordsMatch = passwordConfirm.length > 0 && password === passwordConfirm;
   
   // Check if password meets all requirements
-  const isPasswordValid = React.useMemo(() => {
-    return passwordRequirements.minLength &&
-           passwordRequirements.hasUpperCase &&
-           passwordRequirements.hasLowerCase &&
-           passwordRequirements.hasNumber &&
-           passwordRequirements.hasSpecialChar;
+  const isPasswordValidForForm = React.useMemo(() => {
+    return isPasswordValid(passwordRequirements);
   }, [passwordRequirements]);
   
   // Check if username is valid (not empty, minimum 3 characters)
@@ -78,8 +64,8 @@ export default function RegisterCredentials() {
   
   // Form is valid if all conditions are met
   const isFormValid = React.useMemo(() => {
-    return isUsernameValid && isPasswordValid && passwordsMatch;
-  }, [isUsernameValid, isPasswordValid, passwordsMatch]);
+    return isUsernameValid && isPasswordValidForForm && passwordsMatch;
+  }, [isUsernameValid, isPasswordValidForForm, passwordsMatch]);
   const requiresUsernameAvailabilityCheck = React.useMemo(
     () => trimmedUsername.length >= 3,
     [trimmedUsername]
@@ -115,11 +101,7 @@ export default function RegisterCredentials() {
     // Real-time validation
     if (text.length > 0) {
       const requirements = checkPasswordRequirements(text);
-      const allMet = requirements.minLength &&
-                     requirements.hasUpperCase &&
-                     requirements.hasLowerCase &&
-                     requirements.hasNumber &&
-                     requirements.hasSpecialChar;
+      const allMet = isPasswordValid(requirements);
       
       if (!allMet) {
         setPasswordError("Password does not meet all requirements");

--- a/frontend/app/(tabs)/settings/_layout.tsx
+++ b/frontend/app/(tabs)/settings/_layout.tsx
@@ -1,0 +1,10 @@
+import * as React from "react";
+import { Stack } from "expo-router";
+
+export default function SettingsLayout() {
+  return React.createElement(Stack, {
+    screenOptions: {
+      headerShown: false,
+    },
+  });
+}

--- a/frontend/app/(tabs)/settings/change-password.tsx
+++ b/frontend/app/(tabs)/settings/change-password.tsx
@@ -1,0 +1,488 @@
+import * as React from "react";
+import {
+  View,
+  Text,
+  Alert,
+  Pressable,
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
+import { useRouter } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import { SafeAreaView } from "react-native-safe-area-context";
+import Button from "../../../components/Button";
+import TextField from "../../../components/TextField";
+import { useAuth } from "../../../contexts/AuthContext";
+import { changePassword } from "../../../services/api";
+import { colors } from "../../../theme/colors";
+import { spacing } from "../../../theme/spacing";
+import { typography } from "../../../theme/typography";
+import { checkPasswordRequirements, isPasswordValid } from "../../../utils/passwordPolicy";
+
+export default function ChangePasswordScreen() {
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [currentPassword, setCurrentPassword] = React.useState("");
+  const [newPassword, setNewPassword] = React.useState("");
+  const [confirmPassword, setConfirmPassword] = React.useState("");
+  const [currentPasswordError, setCurrentPasswordError] = React.useState("");
+  const [newPasswordError, setNewPasswordError] = React.useState("");
+  const [confirmPasswordError, setConfirmPasswordError] = React.useState("");
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [showCurrentPassword, setShowCurrentPassword] = React.useState(false);
+  const [showNewPassword, setShowNewPassword] = React.useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = React.useState(false);
+
+  const requirements = React.useMemo(
+    () => checkPasswordRequirements(newPassword),
+    [newPassword]
+  );
+  const newPasswordMeetsRequirements = React.useMemo(
+    () => isPasswordValid(requirements),
+    [requirements]
+  );
+  const passwordsMatch = confirmPassword.length > 0 && newPassword === confirmPassword;
+
+  const handleCurrentPasswordChange = (text: string) => {
+    setCurrentPassword(text);
+
+    if (text.trim().length === 0) {
+      setCurrentPasswordError("Current password is required");
+      return;
+    }
+
+    setCurrentPasswordError("");
+  };
+
+  const handleNewPasswordChange = (text: string) => {
+    setNewPassword(text);
+
+    const trimmedNewPassword = text.trim();
+    const trimmedCurrentPassword = currentPassword.trim();
+
+    if (trimmedNewPassword.length === 0) {
+      setNewPasswordError("New password is required");
+    } else {
+      const nextRequirements = checkPasswordRequirements(trimmedNewPassword);
+      if (!isPasswordValid(nextRequirements)) {
+        setNewPasswordError("Password does not meet all requirements");
+      } else if (trimmedNewPassword === trimmedCurrentPassword) {
+        setNewPasswordError("New password must be different from current password");
+      } else {
+        setNewPasswordError("");
+      }
+    }
+
+    if (confirmPassword.trim().length > 0) {
+      if (trimmedNewPassword !== confirmPassword.trim()) {
+        setConfirmPasswordError("Passwords do not match");
+      } else {
+        setConfirmPasswordError("");
+      }
+    }
+  };
+
+  const handleConfirmPasswordChange = (text: string) => {
+    setConfirmPassword(text);
+
+    if (text.trim().length === 0) {
+      setConfirmPasswordError("Password confirmation is required");
+      return;
+    }
+
+    if (text.trim() !== newPassword.trim()) {
+      setConfirmPasswordError("Passwords do not match");
+      return;
+    }
+
+    setConfirmPasswordError("");
+  };
+
+  const handleSubmit = async () => {
+    setCurrentPasswordError("");
+    setNewPasswordError("");
+    setConfirmPasswordError("");
+
+    let hasErrors = false;
+    if (!currentPassword.trim()) {
+      setCurrentPasswordError("Current password is required");
+      hasErrors = true;
+    }
+
+    if (!newPassword.trim()) {
+      setNewPasswordError("New password is required");
+      hasErrors = true;
+    } else if (!newPasswordMeetsRequirements) {
+      setNewPasswordError("Password does not meet all requirements");
+      hasErrors = true;
+    } else if (newPassword === currentPassword) {
+      setNewPasswordError("New password must be different from current password");
+      hasErrors = true;
+    }
+
+    if (!confirmPassword.trim()) {
+      setConfirmPasswordError("Password confirmation is required");
+      hasErrors = true;
+    } else if (!passwordsMatch) {
+      setConfirmPasswordError("Passwords do not match");
+      hasErrors = true;
+    }
+
+    if (hasErrors) {
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await changePassword({
+        currentPassword: currentPassword.trim(),
+        newPassword: newPassword.trim(),
+        newPasswordConfirm: confirmPassword.trim(),
+      });
+      Alert.alert("Success", "Password changed successfully", [
+        { text: "OK", onPress: () => router.back() },
+      ]);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to change password";
+
+      if (message.toLowerCase().includes("session") || message.toLowerCase().includes("log in again")) {
+        Alert.alert("Session expired", "Please log in again.");
+        await logout();
+        return;
+      }
+
+      Alert.alert("Change password failed", message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return React.createElement(
+    SafeAreaView,
+    {
+      style: {
+        flex: 1,
+      },
+      edges: ["top", "bottom"],
+    },
+    React.createElement(
+      KeyboardAvoidingView,
+      {
+        style: {
+          flex: 1,
+        },
+        behavior: Platform.OS === "ios" ? "padding" : "height",
+      },
+      React.createElement(
+        ScrollView,
+        {
+          contentContainerStyle: {
+            flexGrow: 1,
+            padding: spacing.lg,
+            gap: spacing.md,
+          },
+          keyboardShouldPersistTaps: "handled",
+        },
+        React.createElement(
+          Text,
+          {
+            style: typography.h1,
+            accessibilityRole: "header",
+          },
+          "Change Password",
+        ),
+        React.createElement(TextField, {
+          value: currentPassword,
+          onChangeText: handleCurrentPasswordChange,
+          error: currentPasswordError,
+          secureTextEntry: !showCurrentPassword,
+          autoComplete: "password",
+          autoCapitalize: "none",
+          autoCorrect: false,
+          spellCheck: false,
+          placeholder: "Current Password",
+          accessibilityLabel: "Current Password",
+          rightIcon: React.createElement(
+            Pressable,
+            {
+              onPress: () => setShowCurrentPassword((prev) => !prev),
+              accessibilityLabel: showCurrentPassword
+                ? "Hide current password"
+                : "Show current password",
+              accessibilityRole: "button",
+              style: {
+                padding: spacing.xs,
+              },
+            },
+            React.createElement(Ionicons, {
+              name: showCurrentPassword ? "eye-off-outline" : "eye-outline",
+              size: 20,
+              color: colors.textSecondary,
+            }),
+          ),
+        }),
+        React.createElement(TextField, {
+          value: newPassword,
+          onChangeText: handleNewPasswordChange,
+          error: newPasswordError,
+          secureTextEntry: !showNewPassword,
+          autoComplete: "new-password",
+          autoCapitalize: "none",
+          autoCorrect: false,
+          spellCheck: false,
+          placeholder: "New Password",
+          accessibilityLabel: "New Password",
+          rightIcon: React.createElement(
+            Pressable,
+            {
+              onPress: () => setShowNewPassword((prev) => !prev),
+              accessibilityLabel: showNewPassword ? "Hide new password" : "Show new password",
+              accessibilityRole: "button",
+              style: {
+                padding: spacing.xs,
+              },
+            },
+            React.createElement(Ionicons, {
+              name: showNewPassword ? "eye-off-outline" : "eye-outline",
+              size: 20,
+              color: colors.textSecondary,
+            }),
+          ),
+        }),
+        newPassword.length > 0 &&
+          React.createElement(
+            View,
+            {
+              style: {
+                marginTop: spacing.sm,
+                paddingLeft: spacing.sm,
+                gap: spacing.xs,
+                marginBottom: spacing.sm,
+              },
+            },
+            React.createElement(
+              Text,
+              {
+                style: {
+                  ...typography.label,
+                  color: colors.textSecondary,
+                },
+              },
+              "Password must contain:"
+            ),
+            React.createElement(
+              View,
+              {
+                style: {
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: spacing.xs,
+                },
+              },
+              React.createElement(Ionicons, {
+                name: requirements.minLength ? "checkmark-circle" : "ellipse-outline",
+                size: 16,
+                color: requirements.minLength ? colors.primary : colors.textSecondary,
+              }),
+              React.createElement(
+                Text,
+                {
+                  style: {
+                    ...typography.label,
+                    fontSize: 12,
+                    color: requirements.minLength ? colors.text : colors.textSecondary,
+                  },
+                },
+                "At least 8 characters",
+              ),
+            ),
+            React.createElement(
+              View,
+              {
+                style: {
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: spacing.xs,
+                },
+              },
+              React.createElement(Ionicons, {
+                name: requirements.hasUpperCase ? "checkmark-circle" : "ellipse-outline",
+                size: 16,
+                color: requirements.hasUpperCase ? colors.primary : colors.textSecondary,
+              }),
+              React.createElement(
+                Text,
+                {
+                  style: {
+                    ...typography.label,
+                    fontSize: 12,
+                    color: requirements.hasUpperCase ? colors.text : colors.textSecondary,
+                  },
+                },
+                "One uppercase letter",
+              ),
+            ),
+            React.createElement(
+              View,
+              {
+                style: {
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: spacing.xs,
+                },
+              },
+              React.createElement(Ionicons, {
+                name: requirements.hasLowerCase ? "checkmark-circle" : "ellipse-outline",
+                size: 16,
+                color: requirements.hasLowerCase ? colors.primary : colors.textSecondary,
+              }),
+              React.createElement(
+                Text,
+                {
+                  style: {
+                    ...typography.label,
+                    fontSize: 12,
+                    color: requirements.hasLowerCase ? colors.text : colors.textSecondary,
+                  },
+                },
+                "One lowercase letter",
+              ),
+            ),
+            React.createElement(
+              View,
+              {
+                style: {
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: spacing.xs,
+                },
+              },
+              React.createElement(Ionicons, {
+                name: requirements.hasNumber ? "checkmark-circle" : "ellipse-outline",
+                size: 16,
+                color: requirements.hasNumber ? colors.primary : colors.textSecondary,
+              }),
+              React.createElement(
+                Text,
+                {
+                  style: {
+                    ...typography.label,
+                    fontSize: 12,
+                    color: requirements.hasNumber ? colors.text : colors.textSecondary,
+                  },
+                },
+                "One number",
+              ),
+            ),
+            React.createElement(
+              View,
+              {
+                style: {
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: spacing.xs,
+                },
+              },
+              React.createElement(Ionicons, {
+                name: requirements.hasSpecialChar ? "checkmark-circle" : "ellipse-outline",
+                size: 16,
+                color: requirements.hasSpecialChar ? colors.primary : colors.textSecondary,
+              }),
+              React.createElement(
+                Text,
+                {
+                  style: {
+                    ...typography.label,
+                    fontSize: 12,
+                    color: requirements.hasSpecialChar ? colors.text : colors.textSecondary,
+                  },
+                },
+                "One special character",
+              ),
+            ),
+          ),
+        React.createElement(TextField, {
+          value: confirmPassword,
+          onChangeText: handleConfirmPasswordChange,
+          error: confirmPasswordError,
+          secureTextEntry: !showConfirmPassword,
+          autoComplete: "off",
+          autoCapitalize: "none",
+          autoCorrect: false,
+          spellCheck: false,
+          placeholder: "Confirm New Password",
+          accessibilityLabel: "Confirm New Password",
+          rightIcon: React.createElement(
+            Pressable,
+            {
+              onPress: () => setShowConfirmPassword((prev) => !prev),
+              accessibilityLabel: showConfirmPassword
+                ? "Hide new password confirmation"
+                : "Show new password confirmation",
+              accessibilityRole: "button",
+              style: {
+                padding: spacing.xs,
+              },
+            },
+            React.createElement(Ionicons, {
+              name: showConfirmPassword ? "eye-off-outline" : "eye-outline",
+              size: 20,
+              color: colors.textSecondary,
+            }),
+          ),
+        }),
+        confirmPassword.length > 0 &&
+          React.createElement(
+            View,
+            {
+              style: {
+                marginTop: spacing.sm,
+                paddingLeft: spacing.sm,
+                flexDirection: "row",
+                alignItems: "center",
+                gap: spacing.xs,
+              },
+            },
+            React.createElement(Ionicons, {
+              name: passwordsMatch ? "checkmark-circle" : "close-circle",
+              size: 16,
+              color: passwordsMatch ? colors.primary : colors.danger,
+            }),
+            React.createElement(
+              Text,
+              {
+                style: {
+                  ...typography.label,
+                  fontSize: 12,
+                  color: colors.text,
+                },
+              },
+              passwordsMatch ? "Passwords match" : "Passwords do not match",
+            ),
+          ),
+        React.createElement(Button, {
+          onPress: handleSubmit,
+          title: "Save Password",
+          loading: isSubmitting,
+          disabled: isSubmitting,
+          style: {
+            marginTop: spacing.lg,
+          },
+          accessibilityLabel: "Save Password",
+          accessibilityRole: "button",
+          accessibilityHint: "Submit password change request",
+        }),
+        React.createElement(Button, {
+          onPress: () => router.back(),
+          title: "Cancel",
+          variant: "secondary",
+          disabled: isSubmitting,
+          accessibilityLabel: "Cancel",
+          accessibilityRole: "button",
+          accessibilityHint: "Return to settings without changing password",
+        }),
+      ),
+    ),
+  );
+}

--- a/frontend/app/(tabs)/settings/index.tsx
+++ b/frontend/app/(tabs)/settings/index.tsx
@@ -1,21 +1,14 @@
-/**
- * Settings screen - app configuration and user preferences.
- *
- * This tab screen, accessible at "/settings", allows users to configure app settings,
- * manage preferences, and access account-related options like notifications, privacy, etc.
- *
- * Currently a placeholder screen that will be expanded with settings management features.
- * Uses React.createElement (non-JSX) to match the project's TypeScript configuration.
- */
 import * as React from "react";
 import { View, Text } from "react-native";
+import { useRouter } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
-import Button from "../../components/Button";
-import { useAuth } from "../../contexts/AuthContext";
-import { spacing } from "../../theme/spacing";
-import { typography } from "../../theme/typography";
+import Button from "../../../components/Button";
+import { useAuth } from "../../../contexts/AuthContext";
+import { spacing } from "../../../theme/spacing";
+import { typography } from "../../../theme/typography";
 
-export default function Settings() {
+export default function SettingsScreen() {
+  const router = useRouter();
   const { logout } = useAuth();
   const [isLoggingOut, setIsLoggingOut] = React.useState(false);
 
@@ -56,6 +49,13 @@ export default function Settings() {
         },
         "Settings",
       ),
+      React.createElement(Button, {
+        onPress: () => router.push("/settings/change-password"),
+        title: "Change Password",
+        accessibilityLabel: "Change Password",
+        accessibilityRole: "button",
+        accessibilityHint: "Go to the change password screen",
+      }),
       React.createElement(
         View,
         {
@@ -80,4 +80,3 @@ export default function Settings() {
     ),
   );
 }
-

--- a/frontend/services/__tests__/api.test.ts
+++ b/frontend/services/__tests__/api.test.ts
@@ -3,6 +3,7 @@
  */
 
 import type {
+  ChangePasswordResponse,
   LoginResponse,
   RefreshTokenResponse,
   RegisterRequest,
@@ -442,5 +443,105 @@ describe("register", () => {
         lastName: "User",
       })
     ).rejects.toThrow("No backend URL configured");
+  });
+});
+
+describe("changePassword", () => {
+  const mockGetAccessToken = jest.fn();
+
+  beforeEach(() => {
+    jest.doMock("../tokenStorage", () => ({
+      getAccessToken: mockGetAccessToken,
+    }));
+    apiModule = require("../api");
+  });
+
+  afterEach(() => {
+    jest.dontMock("../tokenStorage");
+  });
+
+  it("sends authenticated POST request and returns response", async () => {
+    mockGetAccessToken.mockResolvedValueOnce("access-token-123");
+    const mockResponse: ChangePasswordResponse = {
+      message: "Password changed successfully",
+    };
+
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await apiModule.changePassword({
+      currentPassword: "OldPass123!",
+      newPassword: "NewPass123!",
+      newPasswordConfirm: "NewPass123!",
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://test-api.example.com/password/change",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer access-token-123",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          currentPassword: "OldPass123!",
+          newPassword: "NewPass123!",
+          newPasswordConfirm: "NewPass123!",
+        }),
+      })
+    );
+    expect(result).toEqual(mockResponse);
+  });
+
+  it("throws when no access token is available", async () => {
+    mockGetAccessToken.mockResolvedValueOnce(null);
+
+    await expect(
+      apiModule.changePassword({
+        currentPassword: "OldPass123!",
+        newPassword: "NewPass123!",
+        newPasswordConfirm: "NewPass123!",
+      })
+    ).rejects.toThrow("You are not authenticated. Please log in again.");
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("throws session-expired message on 401", async () => {
+    mockGetAccessToken.mockResolvedValueOnce("access-token-123");
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json: async () => ({ error: "Invalid token" }),
+    });
+
+    await expect(
+      apiModule.changePassword({
+        currentPassword: "OldPass123!",
+        newPassword: "NewPass123!",
+        newPasswordConfirm: "NewPass123!",
+      })
+    ).rejects.toThrow("Your session has expired. Please log in again.");
+  });
+
+  it("uses API error message for non-401 failures", async () => {
+    mockGetAccessToken.mockResolvedValueOnce("access-token-123");
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: async () => ({ error: "Current password is incorrect" }),
+    });
+
+    await expect(
+      apiModule.changePassword({
+        currentPassword: "wrong-password",
+        newPassword: "NewPass123!",
+        newPasswordConfirm: "NewPass123!",
+      })
+    ).rejects.toThrow("Current password is incorrect");
   });
 });

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1,6 +1,7 @@
 /**
  * API service for making HTTP requests to the backend.
  */
+import { getAccessToken } from "./tokenStorage";
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL;
 
@@ -70,11 +71,22 @@ export interface RegisterResponse {
   username: string;
 }
 
+<<<<<<< HEAD
 export interface AvailabilityCheckResponse {
   available: boolean;
   username?: string;
   email?: string;
   error?: boolean;
+=======
+export interface ChangePasswordRequest {
+  currentPassword: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+}
+
+export interface ChangePasswordResponse {
+  message: string;
+>>>>>>> 07c3b48 (updated frontend to update live, implemented frontend)
 }
 
 export interface LandmarkResult {
@@ -215,6 +227,7 @@ export async function register(userData: RegisterRequest): Promise<RegisterRespo
 }
 
 /**
+<<<<<<< HEAD
  * Checks if a username is available during registration.
  * Returns an explicit error flag so the UI can show an "unknown" state.
  */
@@ -324,6 +337,40 @@ export async function checkEmailAvailability(
     console.warn("[API] check-email request error:", error);
     return fallbackResponse;
   }
+=======
+ * Changes the currently authenticated user's password.
+ */
+export async function changePassword(
+  request: ChangePasswordRequest
+): Promise<ChangePasswordResponse> {
+  const base = requireApiUrl();
+  const accessToken = await getAccessToken();
+
+  if (!accessToken) {
+    throw new Error("You are not authenticated. Please log in again.");
+  }
+
+  const response = await fetch(`${base}/password/change`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(request),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    const error: ApiError = data;
+    if (response.status === 401) {
+      throw new Error("Your session has expired. Please log in again.");
+    }
+    throw new Error(error.error || `Password change failed: ${response.statusText}`);
+  }
+
+  return data as ChangePasswordResponse;
+>>>>>>> 07c3b48 (updated frontend to update live, implemented frontend)
 }
 
 /**

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -71,13 +71,13 @@ export interface RegisterResponse {
   username: string;
 }
 
-<<<<<<< HEAD
 export interface AvailabilityCheckResponse {
   available: boolean;
   username?: string;
   email?: string;
   error?: boolean;
-=======
+}
+
 export interface ChangePasswordRequest {
   currentPassword: string;
   newPassword: string;
@@ -86,7 +86,6 @@ export interface ChangePasswordRequest {
 
 export interface ChangePasswordResponse {
   message: string;
->>>>>>> 07c3b48 (updated frontend to update live, implemented frontend)
 }
 
 export interface LandmarkResult {
@@ -227,7 +226,6 @@ export async function register(userData: RegisterRequest): Promise<RegisterRespo
 }
 
 /**
-<<<<<<< HEAD
  * Checks if a username is available during registration.
  * Returns an explicit error flag so the UI can show an "unknown" state.
  */
@@ -337,7 +335,9 @@ export async function checkEmailAvailability(
     console.warn("[API] check-email request error:", error);
     return fallbackResponse;
   }
-=======
+}
+
+/**
  * Changes the currently authenticated user's password.
  */
 export async function changePassword(
@@ -370,7 +370,6 @@ export async function changePassword(
   }
 
   return data as ChangePasswordResponse;
->>>>>>> 07c3b48 (updated frontend to update live, implemented frontend)
 }
 
 /**

--- a/frontend/services/tokenStorage.ts
+++ b/frontend/services/tokenStorage.ts
@@ -6,12 +6,11 @@
  * Also includes automatic token refresh functionality to keep users logged in.
  */
 
-import * as SecureStore from 'expo-secure-store';
-import { refreshToken } from "./api";
+import * as SecureStore from "expo-secure-store";
 
-const ACCESS_TOKEN_KEY = 'accessToken';
-const ID_TOKEN_KEY = 'idToken';
-const REFRESH_TOKEN_KEY = 'refreshToken';
+const ACCESS_TOKEN_KEY = "accessToken";
+const ID_TOKEN_KEY = "idToken";
+const REFRESH_TOKEN_KEY = "refreshToken";
 
 export interface Tokens {
   accessToken: string;
@@ -30,8 +29,8 @@ export async function storeTokens(tokens: Tokens): Promise<void> {
       SecureStore.setItemAsync(REFRESH_TOKEN_KEY, tokens.refreshToken),
     ]);
   } catch (error) {
-    console.error('Error storing tokens:', error);
-    throw new Error('Failed to store authentication tokens');
+    console.error("Error storing tokens:", error);
+    throw new Error("Failed to store authentication tokens");
   }
 }
 
@@ -42,7 +41,7 @@ export async function getAccessToken(): Promise<string | null> {
   try {
     return await SecureStore.getItemAsync(ACCESS_TOKEN_KEY);
   } catch (error) {
-    console.error('Error retrieving access token:', error);
+    console.error("Error retrieving access token:", error);
     return null;
   }
 }
@@ -54,7 +53,7 @@ export async function getIdToken(): Promise<string | null> {
   try {
     return await SecureStore.getItemAsync(ID_TOKEN_KEY);
   } catch (error) {
-    console.error('Error retrieving ID token:', error);
+    console.error("Error retrieving ID token:", error);
     return null;
   }
 }
@@ -66,7 +65,7 @@ export async function getRefreshToken(): Promise<string | null> {
   try {
     return await SecureStore.getItemAsync(REFRESH_TOKEN_KEY);
   } catch (error) {
-    console.error('Error retrieving refresh token:', error);
+    console.error("Error retrieving refresh token:", error);
     return null;
   }
 }
@@ -92,7 +91,7 @@ export async function getTokens(): Promise<Tokens | null> {
 
     return null;
   } catch (error) {
-    console.error('Error retrieving tokens:', error);
+    console.error("Error retrieving tokens:", error);
     return null;
   }
 }
@@ -108,8 +107,8 @@ export async function clearTokens(): Promise<void> {
       SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY),
     ]);
   } catch (error) {
-    console.error('Error clearing tokens:', error);
-    throw new Error('Failed to clear authentication tokens');
+    console.error("Error clearing tokens:", error);
+    throw new Error("Failed to clear authentication tokens");
   }
 }
 
@@ -121,7 +120,7 @@ export async function isAuthenticated(): Promise<boolean> {
     const tokens = await getTokens();
     return tokens !== null;
   } catch (error) {
-    console.error('Error checking authentication status:', error);
+    console.error("Error checking authentication status:", error);
     return false;
   }
 }
@@ -186,6 +185,7 @@ export async function autoRefreshTokens(): Promise<boolean> {
     // Attempt to refresh the token
     // If the endpoint doesn't exist (404), this will throw an error
     // which we catch and handle gracefully
+    const { refreshToken } = await import("./api");
     const newTokens = await refreshToken(tokens.refreshToken);
     
     // Store new tokens

--- a/frontend/services/tokenStorage.ts
+++ b/frontend/services/tokenStorage.ts
@@ -185,7 +185,8 @@ export async function autoRefreshTokens(): Promise<boolean> {
     // Attempt to refresh the token
     // If the endpoint doesn't exist (404), this will throw an error
     // which we catch and handle gracefully
-    const { refreshToken } = await import("./api");
+    // Use runtime require to avoid top-level circular imports while keeping Jest mocks compatible.
+    const { refreshToken } = require("./api");
     const newTokens = await refreshToken(tokens.refreshToken);
     
     // Store new tokens

--- a/frontend/utils/passwordPolicy.ts
+++ b/frontend/utils/passwordPolicy.ts
@@ -1,0 +1,27 @@
+export interface PasswordRequirements {
+  minLength: boolean;
+  hasUpperCase: boolean;
+  hasLowerCase: boolean;
+  hasNumber: boolean;
+  hasSpecialChar: boolean;
+}
+
+export function checkPasswordRequirements(password: string): PasswordRequirements {
+  return {
+    minLength: password.length >= 8,
+    hasUpperCase: /[A-Z]/.test(password),
+    hasLowerCase: /[a-z]/.test(password),
+    hasNumber: /[0-9]/.test(password),
+    hasSpecialChar: /[^A-Za-z0-9]/.test(password),
+  };
+}
+
+export function isPasswordValid(requirements: PasswordRequirements): boolean {
+  return (
+    requirements.minLength &&
+    requirements.hasUpperCase &&
+    requirements.hasLowerCase &&
+    requirements.hasNumber &&
+    requirements.hasSpecialChar
+  );
+}


### PR DESCRIPTION
## Summary

Implements authenticated password change in the frontend settings flow and aligns password validation UI with registration.

- Refactors settings tab into a nested stack (`settings/_layout`, `settings/index`, `settings/change-password`) and adds navigation to the new change-password screen.
- Adds `changePassword` API support with bearer access token handling, clear 401/session-expired messaging, and screen-level logout on expired sessions.
- Extracts shared password policy logic into `frontend/utils/passwordPolicy.ts` and reuses it in both registration and change-password flows.
- Standardizes password requirement and password-match indicators to consistent icon-based UI (green checkmarks, outlined/unmatched states) across flows.
- Adds tests for `api.changePassword` and the new change-password screen behavior (validation, success path, and session-expired handling).

closes #112 